### PR TITLE
feat: add data science and engineering ruff config (#87)

### DIFF
--- a/configs/data-science-engineering/ruff.toml
+++ b/configs/data-science-engineering/ruff.toml
@@ -5,13 +5,14 @@ extend-include = ["*.ipynb"]
 extend-exclude = [".ipynb_checkpoints"]
 
 [lint]
-# I is for isort (sorting imports automatically).
-# NPY is for NumPy specific checks.
-# PD is for pandas-vet (Data Science best practices).
+# Enable rules tailored for data science and engineering.
 extend-select = [
-    "I",
-    "NPY",
-    "PD"
+    # https://docs.astral.sh/ruff/rules/#isort-i
+    "I",      # isort: Import sorting
+    # https://docs.astral.sh/ruff/rules/#numpy-specific-rules-npy
+    "NPY",    # NumPy-specific rules: NumPy conventions
+    # https://docs.astral.sh/ruff/rules/#pandas-vet-pd
+    "PD",     # pandas-vet: Pandas code checks
 ]
 # Ignore rules that conflict with `ruff format` (formatter-managed concerns).
 # Keep this in sync with other curated configs (e.g. fastapi/ruff.toml).


### PR DESCRIPTION
Hi! This PR resolves #87. I have added the initial ruff.toml configuration for Data Science and Data Engineering, including NPY and PD rules as requested

## Summary by Sourcery

New Features:
- Introduce a dedicated Ruff config enabling linting for Jupyter notebooks and data science focused rules (NumPy and pandas).