### PR TITLE
ci: add documentation build validation

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -61,12 +61,6 @@ docs = [
     "mkdocs-literate-nav>=0.6.2",
     "mkdocs-material>=9.7.5",
     "mkdocstrings[python]>=1.0.3",
-    # Pygments 2.20.0 (released 2026-03-29) changes HtmlFormatter to call html.escape()
-    # on the filename kwarg. pymdownx 10.21 explicitly passes filename=None for code
-    # fences without a title attribute, causing an AttributeError. Pin until fixed upstream.
-    # Track upstream status in pymdown-extensions issues:
-    # https://github.com/facelessuser/pymdown-extensions/issues/2864
-    "pygments>=2.18.0,<2.20",
 ]
 
 [tool.uv]

--- a/uv.lock
+++ b/uv.lock
@@ -1104,24 +1104,24 @@ wheels = [
 
 [[package]]
 name = "pygments"
-version = "2.19.2"
+version = "2.20.0"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/b0/77/a5b8c569bf593b0140bde72ea885a803b82086995367bf2037de0159d924/pygments-2.19.2.tar.gz", hash = "sha256:636cb2477cec7f8952536970bc533bc43743542f70392ae026374600add5b887", size = 4968631, upload-time = "2025-06-21T13:39:12.283Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/c3/b2/bc9c9196916376152d655522fdcebac55e66de6603a76a02bca1b6414f6c/pygments-2.20.0.tar.gz", hash = "sha256:6757cd03768053ff99f3039c1a36d6c0aa0b263438fcab17520b30a303a82b5f", size = 4955991, upload-time = "2026-03-29T13:29:33.898Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/c7/21/705964c7812476f378728bdf590ca4b771ec72385c533964653c68e86bdc/pygments-2.19.2-py3-none-any.whl", hash = "sha256:86540386c03d588bb81d44bc3928634ff26449851e99741617ecb9037ee5ec0b", size = 1225217, upload-time = "2025-06-21T13:39:07.939Z" },
+    { url = "https://files.pythonhosted.org/packages/f4/7e/a72dd26f3b0f4f2bf1dd8923c85f7ceb43172af56d63c7383eb62b332364/pygments-2.20.0-py3-none-any.whl", hash = "sha256:81a9e26dd42fd28a23a2d169d86d7ac03b46e2f8b59ed4698fb4785f946d0176", size = 1231151, upload-time = "2026-03-29T13:29:30.038Z" },
 ]
 
 [[package]]
 name = "pymdown-extensions"
-version = "10.21"
+version = "10.21.2"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "markdown" },
     { name = "pyyaml" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/ba/63/06673d1eb6d8f83c0ea1f677d770e12565fb516928b4109c9e2055656a9e/pymdown_extensions-10.21.tar.gz", hash = "sha256:39f4a020f40773f6b2ff31d2cd2546c2c04d0a6498c31d9c688d2be07e1767d5", size = 853363, upload-time = "2026-02-15T20:44:06.748Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/df/08/f1c908c581fd11913da4711ea7ba32c0eee40b0190000996bb863b0c9349/pymdown_extensions-10.21.2.tar.gz", hash = "sha256:c3f55a5b8a1d0edf6699e35dcbea71d978d34ff3fa79f3d807b8a5b3fa90fbdc", size = 853922, upload-time = "2026-03-29T15:01:55.233Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/6f/2c/5b079febdc65e1c3fb2729bf958d18b45be7113828528e8a0b5850dd819a/pymdown_extensions-10.21-py3-none-any.whl", hash = "sha256:91b879f9f864d49794c2d9534372b10150e6141096c3908a455e45ca72ad9d3f", size = 268877, upload-time = "2026-02-15T20:44:05.464Z" },
+    { url = "https://files.pythonhosted.org/packages/f7/27/a2fc51a4a122dfd1015e921ae9d22fee3d20b0b8080d9a704578bf9deece/pymdown_extensions-10.21.2-py3-none-any.whl", hash = "sha256:5c0fd2a2bea14eb39af8ff284f1066d898ab2187d81b889b75d46d4348c01638", size = 268901, upload-time = "2026-03-29T15:01:53.244Z" },
 ]
 
 [[package]]
@@ -1514,7 +1514,6 @@ docs = [
     { name = "mkdocs-literate-nav" },
     { name = "mkdocs-material" },
     { name = "mkdocstrings", extra = ["python"] },
-    { name = "pygments" },
 ]
 
 [package.metadata]
@@ -1546,7 +1545,6 @@ docs = [
     { name = "mkdocs-literate-nav", specifier = ">=0.6.2" },
     { name = "mkdocs-material", specifier = ">=9.7.5" },
     { name = "mkdocstrings", extras = ["python"], specifier = ">=1.0.3" },
-    { name = "pygments", specifier = ">=2.18.0,<2.20" },
 ]
 
 [[package]]


### PR DESCRIPTION
## Overview

This PR addresses the documentation build failure caused by the recent release of Pygments 2.20.0 and its interaction with `pymdown-extensions`.

Initially, a temporary version pin was added to `pyproject.toml`. However, with the release of `pymdown-extensions` 10.21.2, which officially fixes the crash, the pin has been removed and dependencies have been updated.

Additionally, a new CI job has been added to prevent similar documentation regressions from being merged in the future.

## Changes

### CI / Documentation
- Added `validate-docs-build` job to `.github/workflows/ci.yaml`.
- This job runs `uv run mkdocs build --strict` on all pull requests.
- It ensures documentation validity (links, syntax, and dependency compatibility) before merging.

### Dependencies
- Updated `pymdown-extensions` to 10.21.2.
- Updated `uv.lock` with the latest compatible versions.
- Confirmed that the `pygments<2.20` pin is no longer required.

## Verification

- Verified locally with `uv run mkdocs build --strict`.
- Build succeeds with `pygments==2.20.0` and `pymdown-extensions==10.21.2`.
