### PR TITLE
Prep 0.1.4 Release

### DIFF
--- a/.agents/TESTING.md
+++ b/.agents/TESTING.md
@@ -8,7 +8,7 @@ This document defines the mandatory testing standards and patterns for the `ruff
 - **No Side Effects**: Tests must be isolated and not touch the actual filesystem or make real network calls.
 - **Semantic + Structural Assertions**: When testing TOML merges, always verify **both**:
   1. **Structural/Whitespace**: The file "looks" correct (comments and spacing are preserved).
-  2. **Semantic**: The actual data in the merged result matches the expected values.
+  2. **Semantic**: The actual data in the merged result matches the expected values. Use the [dirty-equals](skills/dirty-equals/SKILL.md) Agent Skill for declarative, concise assertions.
 - **DRY with Fixtures and Parameterization**: Avoid code duplication. Use fixtures for common setups and `@pytest.mark.parametrize` for matrix testing.
 
 ## 2. Tooling and Environment

--- a/.agents/skills/dirty-equals/SKILL.md
+++ b/.agents/skills/dirty-equals/SKILL.md
@@ -1,0 +1,51 @@
+---
+name: dirty-equals
+description: Use for declarative, expressive assertions in Python tests. Ideal for matching complex data structures, TOML documents, and fuzzy matching (URLs, paths, types).
+---
+
+## Overview
+`dirty-equals` allows you to write assertions that are easier to read and maintain. Instead of asserting on every field manually, compare the entire object against a template.
+
+## Common Matchers
+- `IsPositiveInt`: Matches any positive integer.
+- `IsStr(regex=...)`: Matches a string against a regex pattern.
+- `IsInstance(httpx.URL)`: Matches a valid `httpx.URL` object.
+- `IsInstance(pathlib.Path)`: Matches an instance of `pathlib.Path`.
+- `IsPartialDict(expected)`: Matches a dictionary containing at least the specified keys.
+- `IsList(..., order=False)`: Matches a list of items, optionally ignoring order.
+
+## Project Patterns & Gotchas
+
+### matching `tomlkit` documents
+`tomlkit` returns proxy objects. For reliable matching with `dirty-equals`, always call `.unwrap()` on the parsed document or table. We prefer module-level imports for matchers:
+```python
+from dirty_equals import IsPartialDict
+import tomlkit
+
+doc = tomlkit.parse('[tool.ruff]\nline-length = 80')
+# Correct: unwrap to a plain dict
+assert doc.unwrap() == IsPartialDict({
+    "tool": {
+        "ruff": {"line-length": 80}
+    }
+})
+```
+
+### matching `Arguments` (NamedTuple)
+To match our CLI `Arguments`, convert it to a dictionary first using `._asdict()`:
+```python
+from dirty_equals import IsInstance, IsPartialDict
+import httpx
+import pathlib
+
+# Assuming args is a ruff_sync.Arguments instance
+assert args._asdict() == IsPartialDict({
+    "command": "pull",
+    "upstream": (IsInstance(httpx.URL),),
+    "to": IsInstance(pathlib.Path),
+})
+```
+
+### Negative Testing & Logic
+- **Negation**: Use `~` (e.g., `assert x == ~IsNone`).
+- **Combining**: Use `&` and `|` (e.g., `IsInt & IsPositive`).

--- a/.agents/skills/dirty-equals/SKILL.md
+++ b/.agents/skills/dirty-equals/SKILL.md
@@ -1,51 +1,37 @@
 ---
 name: dirty-equals
-description: Use for declarative, expressive assertions in Python tests. Ideal for matching complex data structures, TOML documents, and fuzzy matching (URLs, paths, types).
+description: Use this skill when you need to write declarative, readable, and maintainable assertions in Python tests. It is particularly effective for matching complex data structures, validating merged TOML configurations, and performing fuzzy matching on URLs, file paths, or object types. Use this when the user asks to "assert," "check," "verify," or "match" data in a test, even if they don't explicitly mention "dirty-equals."
 ---
 
+# `dirty-equals` Skill
+
+This skill provides patterns and best practices for writing declarative assertions in the `ruff-sync` project using the `dirty-equals` library.
+
 ## Overview
-`dirty-equals` allows you to write assertions that are easier to read and maintain. Instead of asserting on every field manually, compare the entire object against a template.
 
-## Common Matchers
-- `IsPositiveInt`: Matches any positive integer.
-- `IsStr(regex=...)`: Matches a string against a regex pattern.
-- `IsInstance(httpx.URL)`: Matches a valid `httpx.URL` object.
-- `IsInstance(pathlib.Path)`: Matches an instance of `pathlib.Path`.
-- `IsPartialDict(expected)`: Matches a dictionary containing at least the specified keys.
-- `IsList(..., order=False)`: Matches a list of items, optionally ignoring order.
+Instead of asserting on every field manually, compare against a "dirty" object that matches the expected structure and types.
 
-## Project Patterns & Gotchas
-
-### matching `tomlkit` documents
-`tomlkit` returns proxy objects. For reliable matching with `dirty-equals`, always call `.unwrap()` on the parsed document or table. We prefer module-level imports for matchers:
 ```python
-from dirty_equals import IsPartialDict
-import tomlkit
+from dirty_equals import IsInt, IsPartialDict, IsStr
 
-doc = tomlkit.parse('[tool.ruff]\nline-length = 80')
-# Correct: unwrap to a plain dict
-assert doc.unwrap() == IsPartialDict({
-    "tool": {
-        "ruff": {"line-length": 80}
-    }
-})
+def test_config_logic():
+    result = {"status": "active", "version": 1, "extra": "data"}
+    # Declarative assertion
+    assert result == IsPartialDict({
+        "status": IsStr(regex="act.*"),
+        "version": IsInt(gt=0),
+    })
 ```
 
-### matching `Arguments` (NamedTuple)
-To match our CLI `Arguments`, convert it to a dictionary first using `._asdict()`:
-```python
-from dirty_equals import IsInstance, IsPartialDict
-import httpx
-import pathlib
+## Detailed reference
 
-# Assuming args is a ruff_sync.Arguments instance
-assert args._asdict() == IsPartialDict({
-    "command": "pull",
-    "upstream": (IsInstance(httpx.URL),),
-    "to": IsInstance(pathlib.Path),
-})
-```
+Check these references for project-specific usage and common matchers:
 
-### Negative Testing & Logic
-- **Negation**: Use `~` (e.g., `assert x == ~IsNone`).
-- **Combining**: Use `&` and `|` (e.g., `IsInt & IsPositive`).
+- **[Common Matchers](references/common-matchers.md)**: Standard `dirty-equals` matchers like `IsPartialDict`, `IsInstance`, and more.
+- **[Specialized Matching](references/toml-matching.md)**: Handling `tomlkit.unwrap()` and `Arguments._asdict()`.
+
+## Best Practices
+
+- **Import Style**: Always use the `from dirty_equals import ...` style at the **module level** of your test files.
+- **Semantic Matching**: Use `dirty-equals` for the semantic part of your test assertions, while using string comparisons or `respx` for structural/whitespace checks where appropriate.
+- **Type Safety**: Prefer `IsInstance(httpx.URL)` or `IsInstance(pathlib.Path)` over custom regex for well-known types in the project.

--- a/.agents/skills/dirty-equals/references/common-matchers.md
+++ b/.agents/skills/dirty-equals/references/common-matchers.md
@@ -1,0 +1,51 @@
+# Common `dirty-equals` Matchers
+
+This guide covers the most frequently used `dirty-equals` matchers in the `ruff-sync` project. Standard practice is to import these using the `from` syntax at the module level in test files.
+
+## Structural Matching
+
+- **`IsPartialDict`**: Matches a subset of a dictionary. Essential for verifying specific fields in a larger configuration.
+- **`IsDict`**: Matches an entire dictionary exactly (while still allowing fuzzy values).
+- **`IsList`**: Matches a list, allowing fuzzy matching for elements.
+
+## Type and Instance Matching
+
+- **`IsInstance(type)`**: Matches an object of a specific class. Used for objects like `httpx.URL` or `pathlib.Path`.
+- **`IsStr()`**: Matches any string. Can also specify regex or prefix/suffix.
+- **`IsInt()`**: Matches any integer.
+
+## Examples
+
+### Using `IsPartialDict` and `IsInstance`
+
+```python
+from dirty_equals import IsInstance, IsPartialDict
+import httpx
+import pathlib
+
+# Match a partial dict with mixed types
+assert response_data == IsPartialDict({
+    "url": IsInstance(httpx.URL),
+    "status": "success",
+    "retries": 0,
+})
+```
+
+### String and Path Matching
+
+```python
+from dirty_equals import IsInstance, IsStr
+import pathlib
+
+# Match a path instance
+assert result_path == IsInstance(pathlib.Path)
+
+# Match a string with a specific prefix
+assert error_message == IsStr(regex="^ERROR:.*")
+```
+
+## Logic Matchers
+
+- **`~` (Negation)**: Match values that are *not* the given value (e.g., `assert x == ~IsNone`).
+- **`&` (AND)**: Combine matchers (e.g., `IsInt & IsPositive`).
+- **`|` (OR)**: Combine alternatives.

--- a/.agents/skills/dirty-equals/references/toml-matching.md
+++ b/.agents/skills/dirty-equals/references/toml-matching.md
@@ -1,0 +1,54 @@
+# Specialized Matching for `ruff-sync`
+
+This reference covers project-specific data structures where `dirty-equals` matchers require particular preparation for reliable results.
+
+## TOML Matching (`tomlkit`)
+
+`tomlkit` returns proxy objects (containers and items). To reliably match these with `dirty-equals`, always use `.unwrap()` on the parsed document or table to convert it to plain Python types.
+
+### Correct Pattern
+
+```python
+from dirty_equals import IsPartialDict
+import tomlkit
+
+# Parse some TOML
+doc = tomlkit.parse('[tool.ruff]\nline-length = 80')
+
+# Match the tool.ruff section
+ruff_config = doc["tool"]["ruff"]
+
+# Must use .unwrap()
+assert ruff_config.unwrap() == IsPartialDict({"line-length": 80})
+```
+
+### Potential Gotcha
+Direct matching of `tomlkit` proxy objects without `.unwrap()` can fail because `dirty-equals` may see the proxy's internal attributes rather than its data.
+
+## CLI `Arguments` matching
+
+Our CLI arguments are defined as a `NamedTuple`. To match specific fields without validating the entire object, convert it to a dictionary using `._asdict()`.
+
+### Correct Pattern
+
+```python
+from dirty_equals import IsInstance, IsPartialDict
+import httpx
+import pathlib
+import ruff_sync_cli
+
+# Sample Arguments instance
+args = ruff_sync_cli.Arguments(
+    command="pull",
+    upstream=(httpx.URL("https://example.com"),),
+    to=pathlib.Path("."),
+    # ... other defaults ...
+)
+
+# Convert to dict and match specific fields
+assert args._asdict() == IsPartialDict({
+    "command": "pull",
+    "upstream": (IsInstance(httpx.URL),),
+    "to": IsInstance(pathlib.Path),
+})
+```

--- a/.agents/skills/dirty-equals/trigger_eval.json
+++ b/.agents/skills/dirty-equals/trigger_eval.json
@@ -1,0 +1,30 @@
+[
+  {
+    "query": "I need to check if the tool.ruff section was merged correctly",
+    "should_trigger": true
+  },
+  {
+    "query": "add a unit test that verifies the output",
+    "should_trigger": true
+  },
+  {
+    "query": "where should I use dirty-equals",
+    "should_trigger": true
+  },
+  {
+    "query": "verify that this URL is from github.com",
+    "should_trigger": true
+  },
+  {
+    "query": "assert that the dictionary matches this schema",
+    "should_trigger": true
+  },
+  {
+    "query": "fix this syntax error in the CLI",
+    "should_trigger": false
+  },
+  {
+    "query": "run the tests with coverage",
+    "should_trigger": false
+  }
+]

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -162,6 +162,9 @@ jobs:
           git config user.name "github-actions[bot]"
           git config user.email "github-actions[bot]@users.noreply.github.com"
 
+          # Ensure gh-pages exists and is initialized (required for first run)
+          uv run mike install-gh-pages --push
+
           # Extract version from pyproject.toml in a TOML-aware way using already installed dependencies
           VERSION=$(uv run python - << 'PY'
           import pathlib

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -137,7 +137,7 @@ jobs:
   publish-docs:
     name: Publish Documentation
     if: github.event_name == 'push' && github.ref == 'refs/heads/main'
-    needs: [validate-docs-build]
+    needs: [pre-publish]
     runs-on: ubuntu-latest
     permissions:
       contents: write

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -223,3 +223,9 @@ CI is defined in `.github/workflows/ci.yaml`:
 3. **Pre-commit ruff version**: The ruff version in `.pre-commit-config.yaml` must stay in sync with the version in `pyproject.toml`. The test `test_pre_commit_versions_are_in_sync` enforces this.
 4. **Keep the ruff-sync-usage skill current**: After any change to CLI behavior (new flags, changed exit codes, new configuration keys, updated URL handling, etc.), update `.agents/skills/ruff-sync-usage/` accordingly. The `SKILL.md` covers quick start, workflows, exit codes, and gotchas. Detailed references live in `references/configuration.md`, `references/troubleshooting.md`, and `references/ci-integration.md`.
 5. **No `autouse=True` fixtures**: NEVER use `autouse=True` for pytest fixtures. All fixtures must be explicitly requested by the test functions that require them. This ensures dependencies are explicit and avoids hidden side effects.
+
+## Browser Tool Usage
+
+- **Prefer `read_url_content`**: If you only need to extract text or markdown from a public URL, use `read_url_content`. It is faster and lighter.
+- **Visual Interaction as Last Resort**: Only use `read_browser_page` or manual screen control when a page requires JavaScript execution, authentication, or complex visual interaction.
+- **Task Specificity**: When using the browser subagent, provide highly specific tasks and clear exit criteria to minimize redundant interactions.

--- a/docs/gen_ref_pages.py
+++ b/docs/gen_ref_pages.py
@@ -6,7 +6,7 @@ import pathlib
 
 import mkdocs_gen_files
 
-nav = mkdocs_gen_files.Nav()  # type: ignore[attr-defined,no-untyped-call]
+nav = mkdocs_gen_files.Nav()
 
 for path in sorted(pathlib.Path("src").rglob("*.py")):
     module_path = path.relative_to("src").with_suffix("")

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -42,6 +42,7 @@ ruff-sync = "ruff_sync:main"
 [dependency-groups]
 dev = [
     "coverage>=7.4.4",
+    "dirty-equals>=0.11",
     "invoke>=2.2.0",
     "mypy>=1.10.0",
     "packaging>=26.0",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "ruff-sync"
-version = "0.1.4.dev1"
+version = "0.1.4"
 description = "Synchronize Ruff linter configuration across projects"
 keywords = ["ruff", "linter", "config", "synchronize", "python", "linting", "automation", "tomlkit", "pre-commit"]
 authors = [

--- a/src/ruff_sync/cli.py
+++ b/src/ruff_sync/cli.py
@@ -19,6 +19,7 @@ from typing import (
     Any,
     ClassVar,
     Final,
+    Literal,
     NamedTuple,
     cast,
 )
@@ -60,6 +61,9 @@ try:
     __version__ = metadata.version("ruff-sync")
 except metadata.PackageNotFoundError:
     __version__ = "0.0.0-dev"
+
+
+CIProvider = Literal[OutputFormat.GITHUB, OutputFormat.GITLAB]
 
 
 LOGGER = logging.getLogger(__name__)
@@ -421,14 +425,24 @@ def _resolve_args(args: Any, config: Mapping[str, Any], initial_to: pathlib.Path
     return ResolvedArgs(upstream, to, cast("Any", exclude), cast("Any", branch), cast("Any", path))
 
 
+def _detect_ci_provider() -> CIProvider | None:
+    """Return the current CI provider, or None if not in a CI environment."""
+    if os.environ.get("GITHUB_ACTIONS") == "true":
+        return OutputFormat.GITHUB
+    if os.environ.get("GITLAB_CI") == "true":
+        return OutputFormat.GITLAB
+    return None
+
+
 def _validate_ci_output_format(args: Arguments) -> None:
     """Log a warning if the specified output format does not match the CI environment."""
-    if os.environ.get("GITHUB_ACTIONS") == "true" and args.output_format == OutputFormat.GITLAB:
+    provider = _detect_ci_provider()
+    if provider is OutputFormat.GITHUB and args.output_format == OutputFormat.GITLAB:
         LOGGER.warning(
             "⚠️ GitLab output format detected in GitHub Actions environment. "
             "Did you mean '--output-format github'?"
         )
-    elif os.environ.get("GITLAB_CI") == "true" and args.output_format == OutputFormat.GITHUB:
+    elif provider is OutputFormat.GITLAB and args.output_format == OutputFormat.GITHUB:
         LOGGER.warning(
             "⚠️ GitHub output format detected in GitLab CI environment. "
             "Did you mean '--output-format gitlab'?"

--- a/src/ruff_sync/cli.py
+++ b/src/ruff_sync/cli.py
@@ -420,6 +420,20 @@ def _resolve_args(args: Any, config: Mapping[str, Any], initial_to: pathlib.Path
     return ResolvedArgs(upstream, to, cast("Any", exclude), cast("Any", branch), cast("Any", path))
 
 
+def _validate_ci_output_format(args: Arguments) -> None:
+    """Log a warning if the specified output format does not match the CI environment."""
+    if os.environ.get("GITHUB_ACTIONS") == "true" and args.output_format == OutputFormat.GITLAB:
+        LOGGER.warning(
+            "⚠️ GitLab output format detected in GitHub Actions environment. "
+            "Did you mean '--output-format github'?"
+        )
+    elif os.environ.get("GITLAB_CI") == "true" and args.output_format == OutputFormat.GITHUB:
+        LOGGER.warning(
+            "⚠️ GitHub output format detected in GitLab CI environment. "
+            "Did you mean '--output-format gitlab'?"
+        )
+
+
 def main() -> int:
     """Run the ruff-sync CLI."""
     # Handle backward compatibility: default to 'pull' if no command provided
@@ -498,6 +512,9 @@ def main() -> int:
         resolve_raw_url(u, branch=res_branch, path=res_path) for u in upstream
     )
     exec_args = exec_args._replace(upstream=resolved_upstream)
+
+    # Warn if the specified output format doesn't match the current CI environment
+    _validate_ci_output_format(exec_args)
 
     try:
         if exec_args.command == "check":

--- a/src/ruff_sync/cli.py
+++ b/src/ruff_sync/cli.py
@@ -51,6 +51,7 @@ if TYPE_CHECKING:
 __all__: Final[list[str]] = [
     "Arguments",
     "ColoredFormatter",
+    "OutputFormat",
     "get_config",
     "main",
 ]

--- a/tests/test_basic.py
+++ b/tests/test_basic.py
@@ -15,6 +15,7 @@ import httpx
 import pytest
 import respx
 import tomlkit
+from dirty_equals import IsPartialDict
 from httpx import URL
 from pytest import param
 from tomlkit import TOMLDocument, document
@@ -322,19 +323,9 @@ async def test_sync_updates_ruff_config(
     print(f"\nUpdated tool.ruff\n{sep_str}\n{tomlkit.dumps(updated_ruff_config)}")
     assert original_toml != updated_toml
 
-    assert set(original_ruff_config.keys()).issubset(set(updated_ruff_config.keys()))
-
-    # Ensure the updated ruff config has the same keys as the original
-    for key in original_ruff_config:
-        assert key in updated_ruff_config, f"Original key {key} was not in updated ruff config"
-
-    # Ensure the updated ruff config has the expected updated values from upstream
+    # Ensure the updated ruff config contains all original keys and matches upstream values
     upstream_ruff_config: Table = tomlkit.parse(upstream_toml)["tool"]["ruff"]  # type: ignore[index,assignment]
-    print("Upstream updates...")
-    for key, value in upstream_ruff_config.items():
-        print(f"  {key}", end=" ")
-        assert updated_ruff_config[key] == value, f"{key} was not updated"
-        print("✅")
+    assert updated_ruff_config.unwrap() == IsPartialDict(upstream_ruff_config.unwrap())
 
 
 @contextlib.contextmanager
@@ -504,7 +495,10 @@ def test_upstream_resolution_multiple_cli(patch_cli: CLIPatch):
     ruff_sync.main()
 
     assert len(patch_cli.captured_args) == 1
-    assert patch_cli.captured_args[0].upstream == (URL("http://u1.com"), URL("http://u2.com"))
+    assert patch_cli.captured_args[0].upstream == (
+        URL("http://u1.com"),
+        URL("http://u2.com"),
+    )
 
 
 def test_upstream_resolution_multiple_config(patch_cli: CLIPatch):
@@ -515,7 +509,10 @@ def test_upstream_resolution_multiple_config(patch_cli: CLIPatch):
     ruff_sync.main()
 
     assert len(patch_cli.captured_args) == 1
-    assert patch_cli.captured_args[0].upstream == (URL("http://u1.com"), URL("http://u2.com"))
+    assert patch_cli.captured_args[0].upstream == (
+        URL("http://u1.com"),
+        URL("http://u2.com"),
+    )
 
 
 def test_upstream_resolution_cli_precedence_over_config(patch_cli: CLIPatch) -> None:

--- a/tests/test_basic.py
+++ b/tests/test_basic.py
@@ -326,6 +326,7 @@ async def test_sync_updates_ruff_config(
     # Ensure the updated ruff config contains all original keys and matches upstream values
     upstream_ruff_config: Table = tomlkit.parse(upstream_toml)["tool"]["ruff"]  # type: ignore[index,assignment]
     assert updated_ruff_config.unwrap() == IsPartialDict(upstream_ruff_config.unwrap())
+    assert set(original_ruff_config.keys()).issubset(updated_ruff_config.keys())
 
 
 @contextlib.contextmanager

--- a/tests/test_ci_validation.py
+++ b/tests/test_ci_validation.py
@@ -41,6 +41,11 @@ if TYPE_CHECKING:
             None,
         ),
         (
+            {"GITHUB_ACTIONS": "true", "GITLAB_CI": "true"},
+            OutputFormat.GITLAB,
+            IsStr(regex=".*GitLab output format detected in GitHub Actions environment.*"),
+        ),
+        (
             {},
             OutputFormat.GITHUB,
             None,
@@ -52,7 +57,7 @@ def test_validate_ci_output_format(
     caplog: LogCaptureFixture,
     env_vars: dict[str, str],
     output_format: OutputFormat,
-    expected_warning: str | None,
+    expected_warning: IsStr | None,
 ) -> None:
     """Test that _validate_ci_output_format logs correct warnings for CI mismatches."""
     # Clear existing env vars and set test ones
@@ -75,6 +80,6 @@ def test_validate_ci_output_format(
     _validate_ci_output_format(args)
 
     if expected_warning:
-        assert any(expected_warning == record.message for record in caplog.records)
+        assert any(record.message == expected_warning for record in caplog.records)
     else:
         assert not caplog.records

--- a/tests/test_ci_validation.py
+++ b/tests/test_ci_validation.py
@@ -1,0 +1,80 @@
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
+import pytest
+from dirty_equals import IsStr
+
+from ruff_sync.cli import Arguments, OutputFormat, _validate_ci_output_format
+
+if TYPE_CHECKING:
+    from _pytest.logging import LogCaptureFixture
+    from _pytest.monkeypatch import MonkeyPatch
+
+
+@pytest.mark.parametrize(
+    ("env_vars", "output_format", "expected_warning"),
+    [
+        (
+            {"GITHUB_ACTIONS": "true"},
+            OutputFormat.GITLAB,
+            IsStr(regex=".*GitLab output format detected in GitHub Actions environment.*"),
+        ),
+        (
+            {"GITLAB_CI": "true"},
+            OutputFormat.GITHUB,
+            IsStr(regex=".*GitHub output format detected in GitLab CI environment.*"),
+        ),
+        (
+            {"GITHUB_ACTIONS": "true"},
+            OutputFormat.GITHUB,
+            None,
+        ),
+        (
+            {"GITLAB_CI": "true"},
+            OutputFormat.GITLAB,
+            None,
+        ),
+        (
+            {"GITHUB_ACTIONS": "true"},
+            OutputFormat.TEXT,
+            None,
+        ),
+        (
+            {},
+            OutputFormat.GITHUB,
+            None,
+        ),
+    ],
+)
+def test_validate_ci_output_format(
+    monkeypatch: MonkeyPatch,
+    caplog: LogCaptureFixture,
+    env_vars: dict[str, str],
+    output_format: OutputFormat,
+    expected_warning: str | None,
+) -> None:
+    """Test that _validate_ci_output_format logs correct warnings for CI mismatches."""
+    # Clear existing env vars and set test ones
+    monkeypatch.delenv("GITHUB_ACTIONS", raising=False)
+    monkeypatch.delenv("GITLAB_CI", raising=False)
+    for k, v in env_vars.items():
+        monkeypatch.setenv(k, v)
+
+    # Create dummy Arguments
+    args = Arguments(
+        command="check",
+        upstream=(),
+        to=None,  # type: ignore[arg-type]
+        exclude=None,  # type: ignore[arg-type]
+        verbose=0,
+        output_format=output_format,
+    )
+
+    caplog.clear()
+    _validate_ci_output_format(args)
+
+    if expected_warning:
+        assert any(expected_warning == record.message for record in caplog.records)
+    else:
+        assert not caplog.records

--- a/uv.lock
+++ b/uv.lock
@@ -1519,7 +1519,7 @@ wheels = [
 
 [[package]]
 name = "ruff-sync"
-version = "0.1.4.dev1"
+version = "0.1.4"
 source = { editable = "." }
 dependencies = [
     { name = "httpx" },

--- a/uv.lock
+++ b/uv.lock
@@ -327,6 +327,15 @@ wheels = [
 ]
 
 [[package]]
+name = "dirty-equals"
+version = "0.11"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/30/1d/c5913ac9d6615515a00f4bdc71356d302437cb74ff2e9aaccd3c14493b78/dirty_equals-0.11.tar.gz", hash = "sha256:f4ac74ee88f2d11e2fa0f65eb30ee4f07105c5f86f4dc92b09eb1138775027c3", size = 128067, upload-time = "2025-11-17T01:51:24.451Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/bb/8d/dbff05239043271dbeace563a7686212a3dd517864a35623fe4d4a64ca19/dirty_equals-0.11-py3-none-any.whl", hash = "sha256:b1d7093273fc2f9be12f443a8ead954ef6daaf6746fd42ef3a5616433ee85286", size = 28051, upload-time = "2025-11-17T01:51:22.849Z" },
+]
+
+[[package]]
 name = "distlib"
 version = "0.4.0"
 source = { registry = "https://pypi.org/simple" }
@@ -1521,6 +1530,7 @@ dependencies = [
 [package.dev-dependencies]
 dev = [
     { name = "coverage" },
+    { name = "dirty-equals" },
     { name = "invoke" },
     { name = "mypy" },
     { name = "packaging" },
@@ -1553,6 +1563,7 @@ requires-dist = [
 [package.metadata.requires-dev]
 dev = [
     { name = "coverage", specifier = ">=7.4.4" },
+    { name = "dirty-equals", specifier = ">=0.11" },
     { name = "invoke", specifier = ">=2.2.0" },
     { name = "mypy", specifier = ">=1.10.0" },
     { name = "packaging", specifier = ">=26.0" },


### PR DESCRIPTION
## Summary by Sourcery

Prepare the 0.1.4 release by finalizing the version, tightening CI/docs publishing, and improving test ergonomics and CI-specific CLI behavior.

New Features:
- Add CLI validation that warns when the selected output format does not match the detected CI environment (GitHub Actions vs GitLab CI).

Bug Fixes:
- Adjust documentation publishing workflow to depend on the pre-publish job and ensure the gh-pages branch is initialized before publishing.

Enhancements:
- Refine Ruff config update tests to use declarative dirty-equals matching for TOML semantics.
- Improve CLI argument resolution tests by formatting multi-URL upstream tuples for readability.

Build:
- Promote project version from 0.1.4.dev1 to 0.1.4 and add dirty-equals as a development dependency.

Documentation:
- Expand agent documentation with browser tool usage guidance and introduce a dedicated dirty-equals skill with common matcher and TOML/Arguments matching references.
- Clarify testing guidelines to recommend the dirty-equals skill for semantic assertions in TOML merge tests.

Tests:
- Add tests for CI output format validation warnings based on CI environment and output format.
- Adopt dirty-equals-based assertions in existing tests to simplify and strengthen configuration matching.