### PR TITLE
Fix Versioned Docs

### DIFF
--- a/.agents/skills/mike/SKILL.md
+++ b/.agents/skills/mike/SKILL.md
@@ -60,9 +60,13 @@ Example in `version_warning.html`:
   </div>
 </div>
 <script>
-  if (window.location.pathname.includes("/dev/")) {
-    document.getElementById("version-warning").style.display = "block";
-  }
+  (function() {
+    var version_warning = document.getElementById("version-warning");
+    if (!version_warning) return;
+    if (window.location.pathname.includes("/dev/") || (window.mike && window.mike.version === "dev")) {
+      version_warning.style.display = "block";
+    }
+  })();
 </script>
 ```
 
@@ -104,3 +108,14 @@ The deployment logic is automated in [.github/workflows/ci.yaml](.github/workflo
 
 > [!TIP]
 > Use `mike serve` locally to preview the version switcher before pushing changes.
+
+## Troubleshooting
+
+### Version Selector Not Appearing
+- **Missing `versions.json`**: Ensure `mike deploy` or `mike update-aliases` has been run. The file must exist at the site root.
+- **Incomplete `versions.json`**: If the current page's version (e.g., `stable`) is not listed in `versions.json`, some themes (like Material) may hide the selector.
+- **`site_url` Case Sensitivity**: On GitHub Pages, ensure `site_url` in `mkdocs.yml` matches the actual deployment URL (usually lowercase). Discrepancies can cause the switcher to fail finding `versions.json` due to 404s.
+- **Redundant Config**: Ensure `theme.version` is NOT set in `mkdocs.yml`. Use `extra.version.provider: mike` instead.
+
+### 404 for `versions.json`
+- If you see a 404 for `/versions.json` but `https://<user>.github.io/<repo>/versions.json` exists, the switcher is looking at the domain root instead of the project root. Verify `site_url` includes the repository name and has a trailing slash.

--- a/.agents/skills/mike/SKILL.md
+++ b/.agents/skills/mike/SKILL.md
@@ -114,7 +114,7 @@ The deployment logic is automated in [.github/workflows/ci.yaml](.github/workflo
 ### Version Selector Not Appearing
 - **Missing `versions.json`**: Ensure `mike deploy` or `mike update-aliases` has been run. The file must exist at the site root.
 - **Incomplete `versions.json`**: If the current page's version (e.g., `stable`) is not listed in `versions.json`, some themes (like Material) may hide the selector.
-- **`site_url` Case Sensitivity**: On GitHub Pages, ensure `site_url` in `mkdocs.yml` matches the actual deployment URL (usually lowercase). Discrepancies can cause the switcher to fail finding `versions.json` due to 404s.
+- **`site_url` Case Sensitivity**: On GitHub Pages, ensure `site_url` in `mkdocs.yml` matches the actual deployment URL (usually lowercase). Discrepancies can cause the switcher to fail to find `versions.json` due to 404s.
 - **Redundant Config**: Ensure `theme.version` is NOT set in `mkdocs.yml`. Use `extra.version.provider: mike` instead.
 
 ### 404 for `versions.json`

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -186,9 +186,8 @@ jobs:
 
           if [[ "$VERSION" == *".dev"* ]]; then
             echo "Deploying DEV documentation..."
-            # Check if 'stable' already exists in mike list to avoid accidentally
-            # being the ONLY version in versions.json if it was somehow cleared.
-            # (mike list returns non-zero if versions.json is missing or handles it)
+            # Note: mike deploy is additive to versions.json on gh-pages.
+            # This updates the 'dev' alias and adds it to the switcher if missing.
             uv run mike deploy --push --update-aliases dev
           else
             echo "Deploying STABLE documentation..."

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -185,7 +185,10 @@ jobs:
           echo "Current Version: $VERSION"
 
           if [[ "$VERSION" == *".dev"* ]]; then
-            echo "Deploying DEV documentation only..."
+            echo "Deploying DEV documentation..."
+            # Check if 'stable' already exists in mike list to avoid accidentally
+            # being the ONLY version in versions.json if it was somehow cleared.
+            # (mike list returns non-zero if versions.json is missing or handles it)
             uv run mike deploy --push --update-aliases dev
           else
             echo "Deploying STABLE documentation..."

--- a/docs/overrides/partials/version_warning.html
+++ b/docs/overrides/partials/version_warning.html
@@ -11,12 +11,15 @@
 
 <script>
   (function() {
-    var version_warning = document.getElementById("version-warning");
+    const version_warning = document.getElementById("version-warning");
     if (!version_warning) return;
 
     // mike provides a 'mike' object with some metadata if available
     // Otherwise fall back to checking the pathname
-    if (window.location.pathname.includes("/dev/") || (window.mike && window.mike.version === "dev")) {
+    const isDev = window.location.pathname.includes("/dev/") ||
+                 (window.mike && typeof window.mike.version === 'string' && window.mike.version === "dev");
+
+    if (isDev) {
       version_warning.style.display = "block";
     }
   })();

--- a/docs/overrides/partials/version_warning.html
+++ b/docs/overrides/partials/version_warning.html
@@ -10,9 +10,15 @@
 </div>
 
 <script>
-  var version_warning = document.getElementById("version-warning");
-  if (window.location.pathname.includes("/dev/")) {
-    version_warning.style.display = "block";
-  }
+  (function() {
+    var version_warning = document.getElementById("version-warning");
+    if (!version_warning) return;
+
+    // mike provides a 'mike' object with some metadata if available
+    // Otherwise fall back to checking the pathname
+    if (window.location.pathname.includes("/dev/") || (window.mike && window.mike.version === "dev")) {
+      version_warning.style.display = "block";
+    }
+  })();
 </script>
 {% endif %}

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -1,6 +1,6 @@
 site_name: ruff-sync
 site_description: Synchronize Ruff linter configuration across Python projects.
-site_url: https://Kilo59.github.io/ruff-sync/
+site_url: https://kilo59.github.io/ruff-sync/
 
 repo_name: Kilo59/ruff-sync
 repo_url: https://github.com/Kilo59/ruff-sync
@@ -26,8 +26,6 @@ theme:
       toggle:
         icon: material/brightness-4
         name: Switch to light mode
-  version:
-    method: mike
   features:
     - content.code.copy
     - content.tabs.link


### PR DESCRIPTION
## Summary by Sourcery

Improve handling and visibility of versioned documentation, especially for the dev version, and fix configuration issues affecting the version selector.

Enhancements:
- Update the version warning script to also detect the dev version using mike metadata when available and guard against missing DOM nodes.
- Clarify and expand mike troubleshooting guidance for version selector and versions.json issues in the SKILL documentation.
- Adjust mkdocs configuration to use the correct lowercase GitHub Pages site_url and rely on mike as the version provider instead of theme.version.method.

CI:
- Refine the CI docs deployment job messaging and document safeguards around deploying dev documentation with mike.