### PR TITLE
feat: implement Ruff rule deprecation validation and strict mode

### DIFF
--- a/.agents/plans/issue-116-config-validation.md
+++ b/.agents/plans/issue-116-config-validation.md
@@ -28,8 +28,8 @@ passing both.
 |---|---|---|---|---|---|
 | 1 (Must Have) | 🔴 | 🟡 Moderate | TOML syntax + Ruff CLI validation | New `validation.py` module; gated by `--validate` in `pull()` | ✅ Completed |
 | 2 (Should Have) | 🟠 | 🟢 Simple | Python version consistency check | `validation.py` + warn when `--validate` is active | ✅ Completed |
-| 3 (Could Have) | 🟡 | 🔴 Complex | Rule deprecation warnings | `validation.py` + subprocess + JSON + DI; gated by `--validate` | ⏳ Pending |
-| 4 (Nice to Have) | 🟢 | 🟢 Simple | `--strict` flag | Upgrades warnings to failures; implies `--validate` | 🚧 In Progress |
+| 3 (Could Have) | 🟡 | 🔴 Complex | Rule deprecation warnings | `validation.py` + subprocess + JSON + DI; gated by `--validate` | ✅ Completed |
+| 4 (Nice to Have) | 🟢 | 🟢 Simple | `--strict` flag | Upgrades warnings to failures; implies `--validate` | ✅ Completed |
 
 ---
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "ruff-sync"
-version = "0.1.6.dev2"
+version = "0.1.6.dev3"
 description = "Synchronize Ruff linter configuration across projects"
 keywords = ["ruff", "linter", "config", "synchronize", "python", "linting", "automation", "tomlkit", "pre-commit"]
 authors = [

--- a/src/ruff_sync/validation.py
+++ b/src/ruff_sync/validation.py
@@ -147,6 +147,7 @@ def check_deprecated_rules(
     is_ruff_toml: bool = False,
     strict: bool = False,
     _deprecated_codes: frozenset[str] | None = None,
+    exclude: Iterable[str] = (),
 ) -> bool:
     """Warn if the merged config references any deprecated Ruff rules.
 
@@ -155,6 +156,7 @@ def check_deprecated_rules(
         is_ruff_toml: True if the document is a standalone ruff.toml.
         strict: If True, treat deprecated rules as a failure.
         _deprecated_codes: Optional set of deprecated codes to use (for testing).
+        exclude: List of keys excluded from the ruff configuration.
 
     Returns:
         True if no deprecated rules are found, or if strict=False.
@@ -176,6 +178,10 @@ def check_deprecated_rules(
 
     found_deprecated = False
     for key in _RULE_LIST_KEYS:
+        full_key = f"lint.{key}" if is_ruff_toml else f"tool.ruff.lint.{key}"
+        if key in exclude or full_key in exclude:
+            continue
+
         rule_list = lint_section.get(key, [])
         if not isinstance(rule_list, list):
             continue
@@ -310,6 +316,8 @@ def validate_merged_config(
     if not is_ruff_toml:
         version_ok = check_python_version_consistency(doc, strict=strict, exclude=exclude)
 
-    deprecated_ok = check_deprecated_rules(doc, is_ruff_toml=is_ruff_toml, strict=strict)
+    deprecated_ok = check_deprecated_rules(
+        doc, is_ruff_toml=is_ruff_toml, strict=strict, exclude=exclude
+    )
 
     return version_ok and deprecated_ok

--- a/src/ruff_sync/validation.py
+++ b/src/ruff_sync/validation.py
@@ -111,7 +111,7 @@ def check_python_version_consistency(
     return True
 
 
-_RULE_LIST_KEYS: frozenset[str] = frozenset({"select", "extend-select", "ignore"})
+_RULE_LIST_KEYS: frozenset[str] = frozenset({"select", "extend-select", "ignore", "extend-ignore"})
 
 
 @functools.lru_cache(maxsize=1)

--- a/src/ruff_sync/validation.py
+++ b/src/ruff_sync/validation.py
@@ -2,6 +2,8 @@
 
 from __future__ import annotations
 
+import functools
+import json
 import logging
 import pathlib
 import re
@@ -107,6 +109,91 @@ def check_python_version_consistency(
         LOGGER.warning(f"⚠️  {msg}")
 
     return True
+
+
+_RULE_LIST_KEYS: frozenset[str] = frozenset({"select", "extend-select", "ignore"})
+
+
+@functools.lru_cache(maxsize=1)
+def _get_deprecated_rule_codes() -> frozenset[str]:
+    """Return the set of deprecated rule codes reported by the installed Ruff version.
+
+    Returns an empty frozenset if ruff is not found or output cannot be parsed.
+    """
+    try:
+        result = subprocess.run(
+            ["ruff", "rule", "--all", "--output-format", "json"],  # noqa: S607
+            capture_output=True,
+            text=True,
+            timeout=30,
+            check=False,
+        )
+        if result.returncode != 0:
+            return frozenset()
+        rules = json.loads(result.stdout)
+        return frozenset(r["code"] for r in rules if r.get("deprecated") is True)
+    except (
+        FileNotFoundError,
+        subprocess.TimeoutExpired,
+        json.JSONDecodeError,
+        KeyError,
+        TypeError,
+    ):
+        return frozenset()
+
+
+def check_deprecated_rules(
+    doc: TOMLDocument,
+    is_ruff_toml: bool = False,
+    strict: bool = False,
+    _deprecated_codes: frozenset[str] | None = None,
+) -> bool:
+    """Warn if the merged config references any deprecated Ruff rules.
+
+    Args:
+        doc: The merged TOML document.
+        is_ruff_toml: True if the document is a standalone ruff.toml.
+        strict: If True, treat deprecated rules as a failure.
+        _deprecated_codes: Optional set of deprecated codes to use (for testing).
+
+    Returns:
+        True if no deprecated rules are found, or if strict=False.
+        False if strict=True and deprecated rules are found.
+    """
+    deprecated_codes = (
+        _deprecated_codes if _deprecated_codes is not None else _get_deprecated_rule_codes()
+    )
+    if not deprecated_codes:
+        return True  # Nothing to check (ruff not found or returned no deprecated rules)
+
+    if is_ruff_toml:
+        lint_section = doc.get("lint", {})
+    else:
+        lint_section = doc.get("tool", {}).get("ruff", {}).get("lint", {})
+
+    if not isinstance(lint_section, dict):
+        return True
+
+    found_deprecated = False
+    for key in _RULE_LIST_KEYS:
+        rule_list = lint_section.get(key, [])
+        if not isinstance(rule_list, list):
+            continue
+        for rule_code in rule_list:
+            rule_str = str(rule_code).strip().upper()
+            if rule_str in deprecated_codes:
+                found_deprecated = True
+                msg = (
+                    f"Upstream config uses deprecated rule '{rule_str}' "
+                    f"(found in [{'lint' if is_ruff_toml else 'tool.ruff.lint'}].{key}). "
+                    "This rule may be removed in a future Ruff version."
+                )
+                if strict:
+                    LOGGER.error(f"❌ {msg}")
+                else:
+                    LOGGER.warning(f"⚠️  {msg}")
+
+    return not (strict and found_deprecated)
 
 
 def validate_toml_syntax(doc: TOMLDocument) -> bool:
@@ -218,6 +305,11 @@ def validate_merged_config(
         return False
     if not validate_ruff_accepts_config(doc, is_ruff_toml=is_ruff_toml, strict=strict):
         return False
+
+    version_ok = True
     if not is_ruff_toml:
-        return check_python_version_consistency(doc, strict=strict, exclude=exclude)
-    return True
+        version_ok = check_python_version_consistency(doc, strict=strict, exclude=exclude)
+
+    deprecated_ok = check_deprecated_rules(doc, is_ruff_toml=is_ruff_toml, strict=strict)
+
+    return version_ok and deprecated_ok

--- a/tests/test_config_validation.py
+++ b/tests/test_config_validation.py
@@ -667,6 +667,16 @@ def test_deprecated_rule_warning_emitted(caplog: pytest.LogCaptureFixture) -> No
     assert "deprecated rule 'UP036'" in caplog.text
 
 
+def test_deprecated_rule_ruff_toml_warning_emitted(caplog: pytest.LogCaptureFixture) -> None:
+    doc = tomlkit.parse('[lint]\nselect = ["UP036"]\n')
+    with caplog.at_level(logging.WARNING, logger="ruff_sync.validation"):
+        result = check_deprecated_rules(
+            doc, is_ruff_toml=True, _deprecated_codes=frozenset({"UP036"})
+        )
+    assert result is True
+    assert "deprecated rule 'UP036'" in caplog.text
+
+
 def test_no_warning_for_valid_rules(caplog: pytest.LogCaptureFixture) -> None:
     doc = tomlkit.parse('[tool.ruff.lint]\nselect = ["E501"]\n')
     with caplog.at_level(logging.WARNING, logger="ruff_sync.validation"):

--- a/tests/test_config_validation.py
+++ b/tests/test_config_validation.py
@@ -21,6 +21,7 @@ import ruff_sync
 from ruff_sync import get_config
 from ruff_sync.cli import LOGGER
 from ruff_sync.validation import (
+    check_deprecated_rules,
     check_python_version_consistency,
     validate_merged_config,
     validate_ruff_accepts_config,
@@ -651,6 +652,51 @@ def test_strict_mode_fails_on_version_mismatch(caplog: pytest.LogCaptureFixture)
 
     assert result is False
     assert "Version mismatch" in caplog.text
+
+
+# ===========================================================================
+# Priority 3 — Rule Deprecation Warnings
+# ===========================================================================
+
+
+def test_deprecated_rule_warning_emitted(caplog: pytest.LogCaptureFixture) -> None:
+    doc = tomlkit.parse('[tool.ruff.lint]\nselect = ["UP036"]\n')
+    with caplog.at_level(logging.WARNING, logger="ruff_sync.validation"):
+        result = check_deprecated_rules(doc, _deprecated_codes=frozenset({"UP036"}))
+    assert result is True
+    assert "deprecated rule 'UP036'" in caplog.text
+
+
+def test_no_warning_for_valid_rules(caplog: pytest.LogCaptureFixture) -> None:
+    doc = tomlkit.parse('[tool.ruff.lint]\nselect = ["E501"]\n')
+    with caplog.at_level(logging.WARNING, logger="ruff_sync.validation"):
+        result = check_deprecated_rules(doc, _deprecated_codes=frozenset({"UP036"}))
+    assert result is True
+    assert "deprecated rule" not in caplog.text
+
+
+def test_deprecated_rules_skipped_when_ruff_unavailable(caplog: pytest.LogCaptureFixture) -> None:
+    doc = tomlkit.parse('[tool.ruff.lint]\nselect = ["UP036"]\n')
+    with caplog.at_level(logging.WARNING, logger="ruff_sync.validation"):
+        result = check_deprecated_rules(doc, _deprecated_codes=frozenset())
+    assert result is True
+    assert "deprecated rule" not in caplog.text
+
+
+def test_strict_mode_fails_on_deprecated_rules(caplog: pytest.LogCaptureFixture) -> None:
+    doc = tomlkit.parse('[tool.ruff.lint]\nselect = ["UP036"]\n')
+    with caplog.at_level(logging.ERROR, logger="ruff_sync.validation"):
+        result = check_deprecated_rules(doc, strict=True, _deprecated_codes=frozenset({"UP036"}))
+    assert result is False
+    assert "deprecated rule 'UP036'" in caplog.text
+
+
+def test_non_strict_mode_passes_on_deprecated_rules(caplog: pytest.LogCaptureFixture) -> None:
+    doc = tomlkit.parse('[tool.ruff.lint]\nselect = ["UP036"]\n')
+    with caplog.at_level(logging.WARNING, logger="ruff_sync.validation"):
+        result = check_deprecated_rules(doc, strict=False, _deprecated_codes=frozenset({"UP036"}))
+    assert result is True
+    assert "deprecated rule 'UP036'" in caplog.text
 
 
 if __name__ == "__main__":

--- a/tests/test_config_validation.py
+++ b/tests/test_config_validation.py
@@ -677,6 +677,24 @@ def test_deprecated_rule_ruff_toml_warning_emitted(caplog: pytest.LogCaptureFixt
     assert "deprecated rule 'UP036'" in caplog.text
 
 
+def test_deprecated_rules_skipped_when_excluded(caplog: pytest.LogCaptureFixture) -> None:
+    doc = tomlkit.parse('[tool.ruff.lint]\nselect = ["UP036"]\n')
+    with caplog.at_level(logging.WARNING, logger="ruff_sync.validation"):
+        result = check_deprecated_rules(
+            doc, _deprecated_codes=frozenset({"UP036"}), exclude=("tool.ruff.lint.select",)
+        )
+    assert result is True
+    assert "deprecated rule" not in caplog.text
+
+    # Also check short name exclusion works
+    with caplog.at_level(logging.WARNING, logger="ruff_sync.validation"):
+        result = check_deprecated_rules(
+            doc, _deprecated_codes=frozenset({"UP036"}), exclude=("select",)
+        )
+    assert result is True
+    assert "deprecated rule" not in caplog.text
+
+
 def test_no_warning_for_valid_rules(caplog: pytest.LogCaptureFixture) -> None:
     doc = tomlkit.parse('[tool.ruff.lint]\nselect = ["E501"]\n')
     with caplog.at_level(logging.WARNING, logger="ruff_sync.validation"):

--- a/uv.lock
+++ b/uv.lock
@@ -1610,7 +1610,7 @@ wheels = [
 
 [[package]]
 name = "ruff-sync"
-version = "0.1.6.dev2"
+version = "0.1.6.dev3"
 source = { editable = "." }
 dependencies = [
     { name = "httpx" },


### PR DESCRIPTION
Adds a new validation check that detects deprecated Ruff rules in the merged configuration by querying the installed Ruff CLI.

- Adds `check_deprecated_rules` to validation logic using `ruff rule --all`
- Implements `--strict` flag support to upgrade validation warnings into failures
- Updates the validation pipeline to report deprecations and handle strict mode enforcement
- Adds comprehensive tests for rule deprecation detection and strict mode behavior

Part of #116

## Summary by Sourcery

Add validation of deprecated Ruff lint rules and integrate it with existing configuration validation and strict mode handling.

New Features:
- Detect deprecated Ruff rule codes in merged configurations by querying the installed Ruff CLI.
- Support treating deprecated rule usage as either warnings or failures depending on strict mode.

Tests:
- Add tests covering deprecated rule detection, logging behavior, Ruff-unavailable scenarios, and strict vs non-strict handling.

Chores:
- Update the internal planning document to mark rule deprecation warnings and strict mode work items as completed.