### PR TITLE
docs: comprehensive update for v0.1.6 validation and configuration

### DIFF
--- a/.agents/TESTING.md
+++ b/.agents/TESTING.md
@@ -5,7 +5,7 @@ This document defines the mandatory testing standards and patterns for the `ruff
 ## 1. Core Principles
 
 - **Every Fix Needs a Test**: Any bug fix must include a reproduction test that fails without the fix and passes with it.
-- **No Side Effects**: Tests must be isolated and not touch the actual filesystem or make real network calls.
+- **No Side Effects**: Tests must be isolated and not touch the actual filesystem or make real network calls. Furthermore, tests must not pollute the CI environment (e.g., writing to `GITHUB_STEP_SUMMARY`). Always mock CI-specific environment variables using `monkeypatch.delenv` if the code under test interacts with them.
 - **Semantic + Structural Assertions**: When testing TOML merges, always verify **both**:
   1. **Structural/Whitespace**: The file "looks" correct (comments and spacing are preserved).
   2. **Semantic**: The actual data in the merged result matches the expected values. Use the [dirty-equals](skills/dirty-equals/SKILL.md) Agent Skill for declarative, concise assertions.

--- a/.agents/args_refactor_plan.md
+++ b/.agents/args_refactor_plan.md
@@ -29,7 +29,7 @@
 | **Duplicated resolution** | `resolve_defaults()` is called 3 times (in `pull`, `check`, `_merge_multiple_upstreams`) with the same args. Each call independently resolves the same values. |
 | **Bloated `resolve_defaults()`** | This function's original purpose was URL parameter defaults (branch, path, exclude). Boolean flags have nothing to do with URL resolution—they were bolted on. |
 | **6-tuple destructuring** | `(branch, path, exclude, validate, strict, pre_commit) = resolve_defaults(...)` is fragile and unreadable. Adding one more field breaks every call site. |
-| **Two representations, unclear boundary** | `Arguments` now holds `MISSING` values, but the CLI layer already resolved them in `_resolve_validate()` / `_resolve_strict()`. So `MISSING` can appear in `Arguments` from two sources: (a) the CLI resolver returned it, or (b) direct construction in tests. The semantic is unclear. |
+| **Two representations, unclear boundary** | `Arguments` now holds `MISSING` values, but the CLI layer already resolved them in `_resolve_validate()` / `_resolve_strict()`. So `MISSING` can appear in `Arguments` from two sources: (a) the CLI resolver returned it, or (b) direct construction in tests. The semantics are unclear. |
 
 ### The real requirement
 

--- a/.agents/args_refactor_plan.md
+++ b/.agents/args_refactor_plan.md
@@ -239,7 +239,7 @@ Remove the `resolve_defaults()` call at the top of `pull()`. Instead, accept
 
 ```python
 async def pull(args: Arguments) -> int:
-    exec = args.resolve()   # single resolution point
+    exec_args = args.resolve()   # single resolution point
 
     # Use exec.validate, exec.strict, exec.pre_commit for logic
     # Use args (original, with MISSING) only for serialize_ruff_sync_config()
@@ -269,7 +269,7 @@ Same pattern: call `args.resolve()` once, use the result for execution:
 
 ```python
 async def check(args: Arguments) -> int:
-    exec = args.resolve()
+    exec_args = args.resolve()
 
     ...
     exit_code = _check_pre_commit_sync(exec.pre_commit, fmt)

--- a/.agents/args_refactor_plan.md
+++ b/.agents/args_refactor_plan.md
@@ -1,0 +1,443 @@
+# Refactoring Plan: Clean Up `strict` / `validate` / `pre_commit` Default Handling
+
+> **Context**: Commit `051ca28` ("low effort handling of strict/validate defaults") changed the
+> `Arguments` NamedTuple to use `bool | MissingType` for `validate`, `strict`, and `pre_commit`,
+> then forced every consumer (`pull`, `check`, `_merge_multiple_upstreams`) to call
+> `resolve_defaults()` at the top of the function and destructure a 6-tuple. This is architecturally
+> bad for several reasons outlined below.
+
+---
+
+## Problem Analysis
+
+### What the commit did
+
+1. Changed `Arguments.validate`, `Arguments.strict`, and `Arguments.pre_commit` from `bool` to
+   `bool | MissingType`.
+2. Expanded `resolve_defaults()` from `(branch, path, exclude) → 3-tuple` to
+   `(branch, path, exclude, validate, strict, pre_commit) → 6-tuple`, mixing two concerns (URL
+   resolution defaults and boolean flag defaults).
+3. Added `resolve_defaults()` calls to the top of `pull()`, `check()`, and
+   `_merge_multiple_upstreams()`, each destructuring the 6-tuple with throw-away `_` variables.
+4. Added `pre_commit` to `ResolvedArgs`, making it carry `bool | MissingType` too.
+
+### Why this is bad
+
+| Issue | Explanation |
+|-------|-------------|
+| **Sentinel leaks into execution logic** | `pull()` and `check()` don't care about `MISSING`—they just need a `bool`. But now their type signatures lie: `args.validate` is `bool \| MissingType`, so every access site needs a guard or a `resolve_defaults()` wrapper. |
+| **Duplicated resolution** | `resolve_defaults()` is called 3 times (in `pull`, `check`, `_merge_multiple_upstreams`) with the same args. Each call independently resolves the same values. |
+| **Bloated `resolve_defaults()`** | This function's original purpose was URL parameter defaults (branch, path, exclude). Boolean flags have nothing to do with URL resolution—they were bolted on. |
+| **6-tuple destructuring** | `(branch, path, exclude, validate, strict, pre_commit) = resolve_defaults(...)` is fragile and unreadable. Adding one more field breaks every call site. |
+| **Two representations, unclear boundary** | `Arguments` now holds `MISSING` values, but the CLI layer already resolved them in `_resolve_validate()` / `_resolve_strict()`. So `MISSING` can appear in `Arguments` from two sources: (a) the CLI resolver returned it, or (b) direct construction in tests. The semantic is unclear. |
+
+### The real requirement
+
+The `MISSING` sentinel is needed for **serialization only** (`serialize_ruff_sync_config`): when
+`--save` is used, we must distinguish "user explicitly passed `--no-strict`" (serialize
+`strict = false`) from "user said nothing about strict" (don't serialize the key at all). Execution
+logic (`pull`, `check`) just needs a plain `bool`.
+
+---
+
+## Proposed Design
+
+**Core idea**: Separate the _transport/serialization_ concern (`MISSING` awareness) from the
+_execution_ concern (plain bools).
+
+### Layer 1: `Arguments` (transport + serialization)
+
+Keep `bool | MissingType` for `validate`, `strict`, and `pre_commit` here. This is the type that
+`serialize_ruff_sync_config()` consumes. It is constructed _once_ in `main()` and passed to
+`serialize_ruff_sync_config()` via `pull()`.
+
+### Layer 2: `ExecutionArgs` (new NamedTuple — execution logic)
+
+A **new** NamedTuple with **only plain `bool`** for `validate`, `strict`, and `pre_commit`. This is
+what `pull()` and `check()` (and `_merge_multiple_upstreams`) actually use for control flow. It is
+derived from `Arguments` via a single call to a new `Arguments.resolve()` method (or a standalone
+`resolve_execution_args()` function).
+
+```
+CLI (argparse) ──► _resolve_args() ──► main() builds Arguments
+                                            │
+                        ┌───────────────────┤
+                        ▼                   ▼
+              serialize_ruff_sync_config  Arguments.resolve()
+              (reads MISSING to decide     ──► ExecutionArgs
+               what to serialize)              (plain bools)
+                                               │
+                                    ┌──────────┼──────────┐
+                                    ▼          ▼          ▼
+                                  pull()    check()   _merge_multiple_upstreams()
+```
+
+---
+
+## Step-by-Step Implementation
+
+### Step 1: Create `ExecutionArgs` NamedTuple
+
+**File**: `src/ruff_sync/cli.py`
+
+Add a new NamedTuple right after the existing `Arguments` class:
+
+```python
+class ExecutionArgs(NamedTuple):
+    """Resolved arguments for execution logic — all sentinels replaced with concrete values."""
+
+    command: str
+    upstream: tuple[URL, ...]
+    to: pathlib.Path
+    exclude: Iterable[str]
+    verbose: int
+    branch: str
+    path: str | None
+    semantic: bool
+    diff: bool
+    init: bool
+    pre_commit: bool      # plain bool — MISSING resolved to default
+    save: bool | None
+    output_format: OutputFormat
+    validate: bool        # plain bool — MISSING resolved to default
+    strict: bool          # plain bool — MISSING resolved to default
+```
+
+> [!NOTE]
+> `save` stays `bool | None` because `None` has meaningful semantics there (trigger
+> from `--init`), and it's already resolved before execution.
+
+### Step 2: Add a `resolve()` method to `Arguments`
+
+**File**: `src/ruff_sync/cli.py`
+
+Add a method to `Arguments` that produces an `ExecutionArgs`:
+
+```python
+class Arguments(NamedTuple):
+    # ... existing fields unchanged ...
+
+    def resolve(self) -> ExecutionArgs:
+        """Resolve all MISSING sentinels to their effective defaults for execution."""
+        _, _, _, eff_validate, eff_strict, eff_pre_commit = resolve_defaults(
+            MISSING,   # branch — already resolved, pass MISSING to skip
+            MISSING,   # path — already resolved, pass MISSING to skip
+            MISSING,   # exclude — already resolved, pass MISSING to skip
+            self.validate,
+            self.strict,
+            self.pre_commit,
+        )
+        return ExecutionArgs(
+            command=self.command,
+            upstream=self.upstream,
+            to=self.to,
+            exclude=self.exclude,
+            verbose=self.verbose,
+            branch=self.branch,
+            path=self.path,
+            semantic=self.semantic,
+            diff=self.diff,
+            init=self.init,
+            pre_commit=eff_pre_commit,
+            save=self.save,
+            output_format=self.output_format,
+            validate=eff_validate,
+            strict=eff_strict,
+        )
+```
+
+> [!IMPORTANT]
+> We still use `resolve_defaults()` for the boolean resolution logic (strict implies
+> validate, defaults), but only call it **once** and only for the boolean fields.
+
+### Step 3: Restore `resolve_defaults()` to its original scope
+
+**File**: `src/ruff_sync/constants.py`
+
+Revert `resolve_defaults()` to its original 3-parameter, 3-return form for URL parameter defaults.
+Extract boolean resolution into a separate function:
+
+```python
+def resolve_defaults(
+    branch: str | MissingType,
+    path: str | None | MissingType,
+    exclude: Iterable[str] | MissingType,
+) -> tuple[str, str | None, Iterable[str]]:
+    """Resolve MISSING sentinel values to their effective defaults.
+
+    This is the single source of truth for MISSING → default resolution for
+    URL-related parameters (branch, path, exclude).
+    """
+    eff_branch = branch if branch is not MISSING else DEFAULT_BRANCH
+    raw_path = path if path is not MISSING else DEFAULT_PATH
+    eff_path: str | None = raw_path or None
+    eff_exclude = exclude if exclude is not MISSING else DEFAULT_EXCLUDE
+    return eff_branch, eff_path, eff_exclude
+
+
+def resolve_bool_flags(
+    validate: bool | MissingType = MISSING,
+    strict: bool | MissingType = MISSING,
+    pre_commit: bool | MissingType = MISSING,
+) -> tuple[bool, bool, bool]:
+    """Resolve MISSING sentinel values for boolean execution flags.
+
+    Returns:
+        A ``(validate, strict, pre_commit)`` tuple with defaults applied.
+        ``strict=True`` implicitly enables ``validate``.
+    """
+    eff_strict = strict if strict is not MISSING else False
+    eff_validate = (validate if validate is not MISSING else False) or eff_strict
+    eff_pre_commit = pre_commit if pre_commit is not MISSING else True
+    return eff_validate, eff_strict, eff_pre_commit
+```
+
+> [!TIP]
+> This is a clean separation: `resolve_defaults` handles URL stuff, `resolve_bool_flags`
+> handles boolean stuff. Neither grows unbounded.
+
+### Step 4: Update `Arguments.resolve()` to use `resolve_bool_flags`
+
+**File**: `src/ruff_sync/cli.py`
+
+Replace the `resolve_defaults()` call in `Arguments.resolve()` with `resolve_bool_flags()`:
+
+```python
+from ruff_sync.constants import resolve_bool_flags
+
+class Arguments(NamedTuple):
+    # ...
+    def resolve(self) -> ExecutionArgs:
+        eff_validate, eff_strict, eff_pre_commit = resolve_bool_flags(
+            self.validate, self.strict, self.pre_commit,
+        )
+        return ExecutionArgs(
+            command=self.command,
+            upstream=self.upstream,
+            to=self.to,
+            exclude=self.exclude,
+            verbose=self.verbose,
+            branch=self.branch,
+            path=self.path,
+            semantic=self.semantic,
+            diff=self.diff,
+            init=self.init,
+            pre_commit=eff_pre_commit,
+            save=self.save,
+            output_format=self.output_format,
+            validate=eff_validate,
+            strict=eff_strict,
+        )
+```
+
+### Step 5: Update `pull()` to use `ExecutionArgs`
+
+**File**: `src/ruff_sync/core.py`
+
+Remove the `resolve_defaults()` call at the top of `pull()`. Instead, accept
+**both** `Arguments` (for serialization) and call `.resolve()` once at the top:
+
+```python
+async def pull(args: Arguments) -> int:
+    exec = args.resolve()   # single resolution point
+
+    # Use exec.validate, exec.strict, exec.pre_commit for logic
+    # Use args (original, with MISSING) only for serialize_ruff_sync_config()
+
+    ...
+    if exec.validate:
+        ...validate_merged_config(..., strict=exec.strict, exclude=exec.exclude)
+
+    ...
+    if should_save:
+        serialize_ruff_sync_config(source_doc, args)  # ← still uses raw args
+
+    ...
+    if exec.pre_commit:
+        sync_pre_commit(...)
+```
+
+> [!WARNING]
+> `serialize_ruff_sync_config()` **must** still receive the original `Arguments` (with
+> `MISSING`) so it knows which flags to write and which to omit. Do NOT pass `ExecutionArgs` here.
+
+### Step 6: Update `check()` to use `ExecutionArgs`
+
+**File**: `src/ruff_sync/core.py`
+
+Same pattern: call `args.resolve()` once, use the result for execution:
+
+```python
+async def check(args: Arguments) -> int:
+    exec = args.resolve()
+
+    ...
+    exit_code = _check_pre_commit_sync(exec.pre_commit, fmt)
+    ...
+```
+
+Remove the `resolve_defaults()` call and the 6-tuple destructuring.
+
+### Step 7: Update `_merge_multiple_upstreams()`
+
+**File**: `src/ruff_sync/core.py`
+
+This function currently calls `resolve_defaults()` to get `branch`, `path`, and `exclude`. Since
+these are already resolved by the time they reach `Arguments` (the CLI layer resolves them), the
+call is actually redundant. However, if the function is also used by code that passes un-resolved
+`Arguments`, we should change its signature to accept `ExecutionArgs` instead:
+
+```python
+async def _merge_multiple_upstreams(
+    target_doc: TOMLDocument,
+    is_target_ruff_toml: bool,
+    args: ExecutionArgs,     # ← changed from Arguments
+    client: httpx.AsyncClient,
+) -> TOMLDocument:
+    # No resolve_defaults() needed — args already has plain values
+    fetch_results = await fetch_upstreams_concurrently(
+        args.upstream, client, branch=args.branch, path=args.path
+    )
+    ...
+```
+
+> [!NOTE]
+> Look at call sites: `_merge_multiple_upstreams` is called from both `pull()` and `check()`.
+> Both will now pass `exec` (the `ExecutionArgs`) instead of raw `args`.
+
+### Step 8: Remove `resolve_defaults` import from `core.py`
+
+**File**: `src/ruff_sync/core.py`
+
+After steps 5–7, `core.py` no longer needs `resolve_defaults` or `MISSING` from constants (unless
+other code in the module still uses them). Clean up the imports.
+
+### Step 9: Clean up `ResolvedArgs`
+
+**File**: `src/ruff_sync/cli.py`
+
+The `ResolvedArgs` NamedTuple was expanded to include `validate: bool | MissingType`,
+`strict: bool | MissingType`, and `pre_commit: bool | MissingType`. These should be reverted to
+exclude the boolean flags. `ResolvedArgs` is only used inside `_resolve_args()` → `main()`, and
+the boolean flags are already individually resolved by `_resolve_validate()` and `_resolve_strict()`.
+
+Two options:
+
+- **Option A (recommended)**: Remove `validate`, `strict`, `pre_commit` from `ResolvedArgs`.
+  Put them back onto `Arguments` directly in `main()` using the existing `_resolve_*` functions
+  (which already return `bool | MissingType`).
+
+- **Option B**: Leave `ResolvedArgs` as-is but document that its purpose is to shuttle values
+  between `_resolve_args()` and `main()`.
+
+With **Option A**, `main()` becomes:
+
+```python
+resolved = _resolve_args(args, config, initial_to)  # no validate/strict/pre_commit
+
+exec_args = Arguments(
+    ...
+    validate=_resolve_validate(args, config),
+    strict=_resolve_strict(args, config),
+    pre_commit=_resolve_pre_commit(args, config),
+    ...
+)
+```
+
+### Step 10: Update tests
+
+**File**: `tests/test_constants.py`
+
+Revert `resolve_defaults` tests to the original 3-tuple assertions:
+
+```python
+def test_resolve_defaults_all_missing():
+    branch, path, exclude = resolve_defaults(MISSING, MISSING, MISSING)
+    assert branch == DEFAULT_BRANCH
+    assert path is None
+    assert exclude == DEFAULT_EXCLUDE
+```
+
+Add **new** tests for `resolve_bool_flags()`:
+
+```python
+from ruff_sync.constants import resolve_bool_flags
+
+def test_resolve_bool_flags_all_missing():
+    validate, strict, pre_commit = resolve_bool_flags(MISSING, MISSING, MISSING)
+    assert validate is False
+    assert strict is False
+    assert pre_commit is True
+
+def test_resolve_bool_flags_strict_implies_validate():
+    validate, strict, pre_commit = resolve_bool_flags(MISSING, True, MISSING)
+    assert validate is True
+    assert strict is True
+
+def test_resolve_bool_flags_explicit_false():
+    validate, strict, pre_commit = resolve_bool_flags(False, False, False)
+    assert validate is False
+    assert strict is False
+    assert pre_commit is False
+```
+
+**File**: `tests/test_serialization.py`
+
+No changes needed — these tests construct `Arguments` with `MISSING` and pass to
+`serialize_ruff_sync_config()`, which still consumes raw `Arguments`.
+
+**File**: `tests/test_config_validation.py`
+
+Update tests that currently destructure 6-tuples from `resolve_defaults()` to use the new API. Tests
+for `pull()` and `check()` already pass `Arguments` objects, so they should work unchanged.
+
+### Step 11: Run full validation
+
+```bash
+uv run ruff check . --fix
+uv run ruff format .
+uv run mypy .
+uv run pytest -vv
+```
+
+---
+
+## Summary of Changes
+
+| File | Change |
+|------|--------|
+| `src/ruff_sync/constants.py` | Revert `resolve_defaults` to 3-param/3-return. Add `resolve_bool_flags()`. |
+| `src/ruff_sync/cli.py` | Add `ExecutionArgs` NamedTuple. Add `Arguments.resolve()` method. Clean up `ResolvedArgs`. |
+| `src/ruff_sync/core.py` | Replace `resolve_defaults()` calls in `pull`/`check`/`_merge_multiple_upstreams` with `args.resolve()`. Remove `MISSING`/`resolve_defaults` imports. |
+| `tests/test_constants.py` | Revert to 3-tuple tests. Add `resolve_bool_flags` tests. |
+| `tests/test_config_validation.py` | Minor updates if any test directly calls `resolve_defaults` with 6 args. |
+
+### What does NOT change
+
+- `Arguments` field types stay `bool | MissingType` for `validate`, `strict`, `pre_commit` (needed for serialization).
+- `serialize_ruff_sync_config()` is unchanged — it still reads `MISSING` from `Arguments`.
+- `_resolve_validate()`, `_resolve_strict()`, `_resolve_pre_commit()` in `cli.py` are unchanged.
+- CLI argument parser is unchanged.
+
+### Architecture benefit
+
+```
+Before (051ca28):
+  Arguments (MISSING everywhere) ──► resolve_defaults() called 3× in core.py
+
+After (this refactor):
+  Arguments (MISSING for serialize) ──► .resolve() ──► ExecutionArgs (plain bools) ──► core logic
+                                           ↑ called ONCE
+```
+
+The sentinel is contained to the serialization boundary. Execution logic gets clean types.
+
+---
+
+## Risks & Mitigations
+
+| Risk | Mitigation |
+|------|------------|
+| Changing `_merge_multiple_upstreams` signature breaks internal callers | It's a private function with only 2 call sites (`pull`, `check`). Both are updated in the same PR. |
+| `ExecutionArgs` adds another NamedTuple | It replaces the ad-hoc 6-tuple destructuring, which is worse. The NamedTuple is self-documenting and type-safe. |
+| Tests that construct `Arguments` directly need `MISSING` for new defaults | Already the case — no change. |

--- a/.agents/decisions/0003-argument-resolution-layers.md
+++ b/.agents/decisions/0003-argument-resolution-layers.md
@@ -1,0 +1,120 @@
+# ADR 0003: Two-Layer Argument Resolution (Transport vs Execution)
+
+---
+status: proposed
+date: 2026-04-10
+decider: User + Agent
+---
+
+## Context
+
+`ruff-sync` uses a `MISSING` sentinel (`MissingType.SENTINEL`) throughout its configuration
+system to distinguish between "the user explicitly set this value" and "the user said nothing."
+This distinction is critical for **serialization**: when `--save` persists CLI arguments to
+`[tool.ruff-sync]` in `pyproject.toml`, only explicitly-set values should be written. A field
+left as `MISSING` means "don't touch this key in the TOML file."
+
+The problem arises when `MISSING` leaks into **execution logic**. Functions like `pull()` and
+`check()` need plain `bool` values to make control-flow decisions (`if validate:`, `if strict:`).
+If these functions receive `bool | MissingType`, every access site needs a guard or a resolution
+call, and the type system stops helping.
+
+A prior attempt (commit `051ca28`) solved this by making `Arguments` carry `bool | MissingType`
+for `validate`, `strict`, and `pre_commit`, then calling `resolve_defaults()` at the top of every
+consumer function. This led to:
+
+- **Triplicated resolution calls** in `pull()`, `check()`, and `_merge_multiple_upstreams()`.
+- **Bloated `resolve_defaults()`** mixing unrelated concerns (URL params + boolean flags).
+- **Fragile 6-tuple destructuring** at every call site.
+- **Unclear ownership** of where sentinels are resolved.
+
+## Decision
+
+Argument handling uses **two distinct layers**:
+
+### Layer 1: Transport / Serialization (`Arguments`)
+
+`Arguments` is the NamedTuple constructed by `main()` after CLI parsing and config merging.
+It carries `bool | MissingType` for fields where the _absence_ of a value is meaningful for
+serialization (`validate`, `strict`, `pre_commit`).
+
+- **Consumed by**: `serialize_ruff_sync_config()` (the `--save` path).
+- **Rule**: Only `serialize_ruff_sync_config()` should inspect `MISSING` on these fields.
+
+### Layer 2: Execution (`ExecutionArgs`)
+
+`ExecutionArgs` is a separate NamedTuple with **only plain `bool`** for all boolean flags.
+All `MISSING` sentinels are resolved to their concrete defaults (e.g., `strict` defaults to
+`False`, `pre_commit` defaults to `True`, `strict=True` implies `validate=True`).
+
+- **Produced by**: `Arguments.resolve()` — called **once** at the top of `pull()` / `check()`.
+- **Consumed by**: All execution logic (`pull`, `check`, `_merge_multiple_upstreams`, `_check_pre_commit_sync`, `validate_merged_config`).
+- **Rule**: Execution functions must never see `MissingType`.
+
+### Resolution Functions
+
+Default resolution is split by concern:
+
+| Function | Scope | Returns |
+|----------|-------|---------|
+| `resolve_defaults(branch, path, exclude)` | URL-related parameters | `(str, str \| None, Iterable[str])` |
+| `resolve_bool_flags(validate, strict, pre_commit)` | Boolean execution flags | `(bool, bool, bool)` |
+
+Neither function should grow to absorb the other's concerns. If a new parameter category
+emerges (e.g., output formatting defaults), it should get its own resolution function.
+
+### Data Flow
+
+```
+CLI (argparse)
+  │
+  ▼
+_resolve_args() + _resolve_validate/strict/pre_commit()
+  │
+  ▼
+main() builds Arguments (MISSING-aware)
+  │
+  ├──► serialize_ruff_sync_config(args)   ← reads MISSING to decide what to write
+  │
+  └──► args.resolve() → ExecutionArgs     ← MISSING → concrete defaults
+         │
+         └──► pull() / check() / internal logic  ← plain bools only
+```
+
+## Consequences
+
+### Easier
+
+- **Type safety**: Execution functions have `bool` fields — no unions, no guards, no runtime
+  ambiguity.
+- **Single resolution point**: `MISSING` → default happens in exactly one place
+  (`Arguments.resolve()`), not scattered across consumer functions.
+- **Extensibility**: Adding a new boolean flag means adding it to both `Arguments` (with
+  `MissingType`) and `ExecutionArgs` (with `bool`), plus a line in `resolve_bool_flags()`.
+  No 6-tuple explosions.
+- **Agent-friendliness**: The pattern is explicit and mechanical — hard to get wrong.
+
+### Harder
+
+- **Two NamedTuples to maintain**: Adding a new field requires updating both `Arguments` and
+  `ExecutionArgs`. This is intentional friction — it forces the developer to think about whether
+  the new field needs `MISSING` semantics.
+- **`pull()` holds two references**: `args` (for serialization) and `exec` (for logic). This is
+  a feature, not a bug — it makes the boundary visible.
+
+### Rules for Future Changes
+
+1. **Never pass `MissingType` to execution logic.** If a function's parameter is `bool`, it must
+   receive `bool`. Use `Arguments.resolve()` to get `ExecutionArgs` first.
+2. **Never call `resolve_defaults()` or `resolve_bool_flags()` inside `pull()` / `check()`.**
+   Call `args.resolve()` once and pass the result down.
+3. **`serialize_ruff_sync_config()` always receives raw `Arguments`**, never `ExecutionArgs`.
+   It needs to see `MISSING` to know what to omit.
+4. **Don't merge resolution functions.** `resolve_defaults` (URL params) and
+   `resolve_bool_flags` (execution flags) serve different concerns. Keep them separate.
+
+## References
+
+- Commit `051ca28` — the "low effort" approach this ADR replaces.
+- Refactoring plan: see conversation artifacts for step-by-step implementation.
+- Related: `MissingType` / `MISSING` sentinel documented in [AGENTS.md](../../AGENTS.md) under "Sentinels & Missing Values."

--- a/.agents/decisions/README.md
+++ b/.agents/decisions/README.md
@@ -6,6 +6,7 @@ This is an internal record of architectural decisions for `ruff-sync`. These doc
 | --- | --- | --- | --- |
 | [0001](./0001-type-refactoring-strategy.md) | 2026-04-05 | Accepted | Type Refactoring Strategy |
 | [0002](./0002-tui-node-ast.md) | 2026-04-05 | Accepted | TUI Node AST Architecture |
+| [0003](./0003-argument-resolution-layers.md) | 2026-04-10 | Proposed | Two-Layer Argument Resolution (Transport vs Execution) |
 
 ---
 *For instructions on how to create or manage ADRs, see the [ADR Skill](../skills/adr/SKILL.md).*

--- a/.agents/decisions/README.md
+++ b/.agents/decisions/README.md
@@ -6,7 +6,7 @@ This is an internal record of architectural decisions for `ruff-sync`. These doc
 | --- | --- | --- | --- |
 | [0001](./0001-type-refactoring-strategy.md) | 2026-04-05 | Accepted | Type Refactoring Strategy |
 | [0002](./0002-tui-node-ast.md) | 2026-04-05 | Accepted | TUI Node AST Architecture |
-| [0003](./0003-argument-resolution-layers.md) | 2026-04-10 | Proposed | Two-Layer Argument Resolution (Transport vs Execution) |
+| [0003](./0003-argument-resolution-layers.md) | 2026-04-10 | Accepted | Two-Layer Argument Resolution (Transport vs Execution) |
 
 ---
 *For instructions on how to create or manage ADRs, see the [ADR Skill](../skills/adr/SKILL.md).*

--- a/.agents/docs_update_plan.md
+++ b/.agents/docs_update_plan.md
@@ -1,0 +1,384 @@
+# Documentation Update Plan (post-v0.1.5)
+
+> **Context**: This plan covers documentation improvements needed after the v0.1.5 release. Changes since that release include: config validation (`--validate`), strict mode (`--strict`), Python version consistency checks, deprecated rule detection, a new `validation.py` module, `ExecutionArgs` refactoring, and boolean flag persistence (`validate` and `strict` in `[tool.ruff-sync]`).
+>
+> Some documentation was partially updated alongside the code changes (usage.md, README.md, configuration.md got the basics). This plan addresses remaining gaps and general improvements.
+
+---
+
+## Task 1: Add `validate` and `strict` to Configuration Reference Table
+
+**File**: `docs/configuration.md`
+**Lines**: 7–16 (the reference table)
+
+**What to do**: Add two new rows to the reference table for the `validate` and `strict` configuration keys. These keys were added to `Config` TypedDict and `ConfKey` enum but are missing from the documentation reference table.
+
+**Add these rows** after the `pre-commit-version-sync` row (line 16):
+
+```markdown
+| `validate` | `bool` | `false` | Run the merged config through Ruff before writing to disk. Aborts the sync if Ruff rejects the config. |
+| `strict` | `bool` | `false` | Treat validation warnings (version mismatches, deprecated rules) as hard failures. Implies `validate = true`. |
+```
+
+**Why**: Users who configure via `pyproject.toml` (not CLI) have no documentation showing these keys exist in the config reference.
+
+---
+
+## Task 2: Add Validation Config Example to Configuration Page
+
+**File**: `docs/configuration.md`
+**Location**: After the "Preserve target version" section (after line 66) and before "Sequential merging"
+
+**What to do**: Add a new example subsection showing how to enable validation persistently via config:
+
+```markdown
+#### Enable validation by default
+
+If you always want the merged config validated before writing, enable it in your configuration:
+
+\`\`\`toml
+[tool.ruff-sync]
+validate = true
+\`\`\`
+
+For even stricter enforcement (treat warnings like Python version mismatches and deprecated rules as hard failures):
+
+\`\`\`toml
+[tool.ruff-sync]
+strict = true  # implies validate = true
+\`\`\`
+```
+
+**Why**: The existing docs only show `--validate` and `--strict` as CLI flags. Users should know they can persist these settings.
+
+---
+
+## Task 3: Add Validation to CI Integration Examples
+
+**File**: `docs/ci-integration.md`
+**Location**: After the "Basic Check" section (after line 30), add a new subsection
+
+**What to do**: Add a new subsection showing how to combine `check` with `--validate`/`--strict` in CI workflows. Insert the following after line 36 (after the annotation note):
+
+```markdown
+#### With Validation
+
+To catch broken or deprecated Ruff configuration during CI, add `--strict` to upgrade validation warnings into failures:
+
+\`\`\`yaml
+name: "Standards Check"
+
+on:
+  pull_request:
+    branches: [main]
+
+jobs:
+  ruff-sync:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: astral-sh/setup-uv@v5
+      - name: Check Ruff Config
+        run: uvx ruff-sync check --semantic --strict --output-format github
+\`\`\`
+
+> [!TIP]
+> `--strict` implies `--validate`. You do not need to pass both flags. This will catch deprecated Ruff rules and Python version mismatches in addition to configuration drift.
+```
+
+**Why**: CI is the most important place to use validation, and there's no CI example showing it.
+
+---
+
+## Task 4: Add Validation to Automated Sync PR Workflow
+
+**File**: `docs/ci-integration.md`
+**Location**: Inside the "Automated Sync PRs" YAML example (line 83)
+
+**What to do**: Update the `run: uvx ruff-sync` line to include `--validate`:
+
+```yaml
+      - name: Pull upstream
+        run: uvx ruff-sync --validate
+```
+
+**Why**: When auto-syncing, you want to catch broken configs before they are committed. A simple one-word addition that significantly improves the example.
+
+---
+
+## Task 5: Add Exit Code for Validation Failure
+
+**File**: `docs/ci-integration.md`
+**Location**: Exit Codes table (lines 150–156)
+
+**What to do**: Check the source code to confirm whether validation failures use an existing exit code or a new one. Based on the current code, `pull()` returns `1` when validation fails. Update the exit code table to clarify this:
+
+Update the row for exit code `1` to explicitly mention validation:
+
+```markdown
+| **1** | Config drift (`check`), validation failure (`pull --validate`), or sync error |
+```
+
+**Why**: Users need to understand what exit code to expect when validation blocks a sync.
+
+---
+
+## Task 6: Update Pre-commit Hook Versions
+
+**File**: `docs/pre-commit.md`
+**Lines**: 15, 26, 43, 45
+
+**What to do**: Update all `rev: v0.1.3` references to `rev: v0.1.5` (or whatever the latest release is). There are four occurrences.
+
+Search for `v0.1.3` in the file and replace with `v0.1.5`.
+
+**Why**: The pre-commit docs reference an outdated version. Users who copy-paste these examples get an old version.
+
+---
+
+## Task 7: Update Pre-defined Configs Page Versions
+
+**File**: `docs/pre-defined-configs.md`
+**Lines**: 42, 80, 118
+
+**What to do**: Update all `--branch v0.1.3` references to `--branch v0.1.5`.
+
+Search for `v0.1.3` in the file and replace with `v0.1.5`.
+
+**Why**: Same reason as Task 6 — hardcoded old version in examples.
+
+---
+
+## Task 8: Add Validation Troubleshooting Entries
+
+**File**: `docs/troubleshooting.md`
+**Location**: After the "Merge conflicts in TOML" section (after line 47), before "Multi-upstream Fetch Failures"
+
+**What to do**: Add three new troubleshooting entries:
+
+```markdown
+### Validation failed: `ruff` not found
+
+**Warning**: `⚠️  \`ruff\` not found on PATH — skipping Ruff config validation.`
+
+**Solution**: This is a soft warning, not a failure. If you explicitly want validation, ensure `ruff` is installed and available on your PATH. If using `uv`, run `uv pip install ruff` or add it to your project's dependencies.
+
+### Python version mismatch
+
+**Warning**: `⚠️  Version mismatch: upstream [tool.ruff] target-version='py39'...`
+
+**Solution**:
+This means the upstream configuration targets a different Python version than your project's `requires-python`. You have three options:
+
+1. **Update upstream**: Coordinate with your team to update the upstream `target-version`.
+2. **Exclude the key**: Add `target-version` to your `exclude` list to manage it locally.
+3. **Ignore the warning**: In non-strict mode, this is informational only and does not block the sync.
+
+In `--strict` mode, this warning becomes a hard failure. See the [Usage Guide](usage.md#validating-before-writing) for details.
+
+### Deprecated rule detected
+
+**Warning**: `⚠️  Upstream config uses deprecated rule 'XXX'...`
+
+**Solution**:
+The upstream configuration references a Ruff rule that has been deprecated. This often happens when the upstream hasn't been updated after a Ruff version bump.
+
+1. **Update upstream**: Replace the deprecated rule with its successor in the upstream config.
+2. **Ignore the warning**: In non-strict mode, deprecated rules are informational warnings only.
+
+In `--strict` mode, deprecated rules cause a hard failure.
+```
+
+**Why**: The troubleshooting page has no entries for the new validation features. Users encountering these messages for the first time need guidance.
+
+---
+
+## Task 9: Update Index Page Feature List
+
+**File**: `docs/index.md`
+**Location**: The "🚀 Key Features" bullet list (lines 13–24)
+
+**What to do**: Add a new bullet for config validation after the "CI Ready" bullet (line 22):
+
+```markdown
+* **✅ Config Validation**: Optionally validate merged configs with Ruff before writing. Strict mode catches deprecated rules and Python version mismatches.
+```
+
+**Why**: The index page feature list is the first thing users see. The new validation capability is a significant feature that should be highlighted.
+
+---
+
+## Task 10: Update Advanced Config Example with Validation Keys
+
+**File**: `docs/examples/advanced-config.toml`
+**Location**: After line 15 (before the closing of the file)
+
+**What to do**: Add the `validate` key to the advanced example to showcase it as a recommended practice:
+
+```toml
+# Validate merged config before writing (catches bad upstream changes)
+validate = true
+```
+
+**Why**: The example files serve as copy-paste templates. Including `validate` in the advanced example normalizes its usage.
+
+---
+
+## Task 11: Add `--no-validate` and `--no-strict` to Command Reference
+
+**File**: `docs/usage.md`
+**Location**: Command Reference section, specifically the `--validate` and `--strict` entries (lines 192–193)
+
+**What to do**: Update the descriptions to mention the `--no-*` variants, since these use `BooleanOptionalAction`:
+
+Line 192, update `--validate` entry:
+```markdown
+* **`--validate` / `--no-validate`**: Run the merged config through Ruff before writing to disk. If Ruff rejects the config (e.g., due to an unknown key), the sync is aborted and the local file is left unchanged. Off by default. Use `--no-validate` to explicitly disable validation even if `validate = true` is set in your config.
+```
+
+Line 193, update `--strict` entry:
+```markdown
+* **`--strict` / `--no-strict`**: Treat validation warnings (such as Python version mismatches or deprecated rules) as hard failures. Implies `--validate` — you do not need to pass both flags. Use `--no-strict` to explicitly disable strict mode even if `strict = true` is in config.
+```
+
+**Why**: The CLI actually supports `--no-validate` and `--no-strict` (via `BooleanOptionalAction`), but the docs don't mention them. Users who set `validate = true` in their config need to know how to opt out for a specific run.
+
+---
+
+## Task 12: Update Agent Skill Configuration Reference
+
+**File**: `.agents/skills/ruff-sync-usage/references/configuration.md`
+**Location**: After the `pre-commit-version-sync` section (after line 101, before "Full Example")
+
+**What to do**: Add two new sections for `validate` and `strict`:
+
+```markdown
+---
+
+### `validate` *(default: `false`)*
+
+When `true`, `ruff-sync` validates the merged configuration by running it through Ruff before writing to disk. If Ruff rejects the config (e.g., due to an unknown key), the sync is aborted and the local file is left unchanged.
+
+\`\`\`toml
+validate = true
+\`\`\`
+
+> [!NOTE]
+> Validation requires `ruff` to be available on PATH. If `ruff` is not found, validation is skipped with a warning.
+
+---
+
+### `strict` *(default: `false`)*
+
+When `true`, all validation warnings (Python version mismatches, deprecated rules) are treated as hard failures. Implies `validate = true`.
+
+\`\`\`toml
+strict = true
+\`\`\`
+```
+
+Also update the "Full Example" block to include these keys:
+
+```toml
+[tool.ruff-sync]
+upstream = [
+    "https://github.com/my-org/python-standards",
+    "https://github.com/my-org/backend-team-rules",
+]
+exclude = [
+    "target-version",
+    "lint.per-file-ignores",
+    "lint.ignore",
+    "lint.isort.known-first-party",
+]
+branch = "main"
+path = "ruff"
+to = "."
+pre-commit-version-sync = true
+validate = true
+```
+
+**Why**: The agent skill's configuration reference is supposed to be the authoritative reference for AI agents. It currently has no mention of `validate` or `strict` as config keys.
+
+---
+
+## Task 13: Update Agent Skill CI Reference with Validation
+
+**File**: `.agents/skills/ruff-sync-usage/references/ci-integration.md`
+**Location**: After the "Basic Drift Check" section (after line 15)
+
+**What to do**: Add a note about combining check + validation:
+
+```markdown
+### With Strict Validation
+
+To also catch deprecated rules and Python version mismatches in CI:
+
+\`\`\`yaml
+- name: Check Ruff config (with validation)
+  run: ruff-sync check --semantic --strict --output-format github
+\`\`\`
+
+`--strict` implies `--validate`. Deprecated rules and version mismatches are upgraded to failures.
+```
+
+**Why**: Keeps the agent skill CI reference in sync with the main docs.
+
+---
+
+## Task 14: Update Pre-commit Skill References
+
+**File**: `.agents/skills/ruff-sync-usage/references/ci-integration.md`
+**Lines**: 166
+
+**What to do**: Update `rev: v0.1.3` to `rev: v0.1.5`.
+
+**Why**: Same version staleness issue as the main docs.
+
+---
+
+## Task 15: Add FAQ Entry for Validation
+
+**File**: `docs/troubleshooting.md`
+**Location**: FAQ section (after line 85)
+
+**What to do**: Add two new FAQ entries:
+
+```markdown
+### Does `--validate` require `ruff` to be installed?
+
+Yes, validation shells out to the `ruff` binary. If `ruff` is not on your `PATH`, validation is silently skipped with a warning. To use validation, ensure Ruff is installed (e.g., via `uv pip install ruff` or as a project dependency).
+
+### What does `--strict` check for?
+
+In addition to the basic config syntax validation from `--validate`, `--strict` upgrades the following warnings to hard failures:
+
+1. **Python version mismatch**: The upstream `target-version` doesn't align with your local `requires-python`.
+2. **Deprecated Ruff rules**: Any rule codes in `lint.select`, `lint.ignore`, `lint.extend-select`, `lint.extend-ignore`, or `lint.extend-fixable` that Ruff reports as deprecated.
+3. **Ruff stderr warnings**: Any warning messages Ruff emits to stderr when parsing the config.
+```
+
+**Why**: These are the most likely questions users will have about the new features.
+
+---
+
+## Execution Order
+
+> [!IMPORTANT]
+> Tasks can be executed in any order. They are independent of each other. However, a logical grouping would be:
+>
+> 1. **Core docs** (Tasks 1-5, 9, 11) — Configuration, usage, CI, and index pages
+> 2. **Version bumps** (Tasks 6-7, 14) — Simple find-and-replace of `v0.1.3` → `v0.1.5`
+> 3. **Troubleshooting** (Tasks 8, 15) — New entries for validation-related issues
+> 4. **Examples** (Task 10) — Updated advanced config example
+> 5. **Agent skill** (Tasks 12-13) — Keep the AI skill references current
+
+## Validation
+
+After all changes, run:
+
+```bash
+uv run mkdocs build --strict 2>&1 | head -50
+```
+
+This will catch any broken links, missing files, or Markdown syntax errors in the documentation. Fix any warnings before considering the task complete.

--- a/.agents/skills/ruff-sync-usage/references/ci-integration.md
+++ b/.agents/skills/ruff-sync-usage/references/ci-integration.md
@@ -14,6 +14,17 @@ Add this step to any existing workflow (e.g., `.github/workflows/ci.yaml`):
 `--semantic` ignores cosmetic differences (comments, whitespace) — only real value or rule changes cause failure.
 `--output-format github` creates inline PR annotations and a structured Job Summary report.
 
+### With Strict Validation
+
+To also catch deprecated rules and Python version mismatches in CI:
+
+```yaml
+- name: Check Ruff config (with validation)
+  run: ruff-sync check --semantic --strict --output-format github
+```
+
+`--strict` implies `--validate`. Deprecated rules and version mismatches are upgraded to failures.
+
 > [!TIP]
 > `ruff-sync` automatically groups multiple drifts in the same file into a single annotation to reduce PR noise.
 
@@ -162,7 +173,7 @@ Run `ruff-sync check` as a pre-commit hook to catch drift before every commit:
 ```yaml
 # .pre-commit-config.yaml
 - repo: https://github.com/Kilo59/ruff-sync
-  rev: v0.1.3   # pin to a release tag
+  rev: v0.1.6   # pin to a release tag
   hooks:
     - id: ruff-sync-check
 ```
@@ -214,7 +225,7 @@ No URL argument needed — it reads `upstream` from `[tool.ruff-sync]`.
 | Code | Meaning |
 |------|----------|
 | **0** | In sync — no drift detected |
-| **1** | Config drift — `[tool.ruff]` values differ from upstream |
+| **1** | Config drift (`check`), validation failure (`pull --validate`), or sync error |
 | **2** | CLI usage error — invalid arguments (reserved by argparse) |
 | **3** | Pre-commit hook drift — use `--pre-commit` flag to enable this check |
 | **4** | Upstream unreachable — HTTP error or network failure |

--- a/.agents/skills/ruff-sync-usage/references/configuration.md
+++ b/.agents/skills/ruff-sync-usage/references/configuration.md
@@ -102,6 +102,29 @@ Requires a `- repo: https://github.com/astral-sh/ruff-pre-commit` entry in `.pre
 
 ---
 
+### `validate` *(default: `false`)*
+
+When `true`, `ruff-sync` validates the merged configuration by running it through Ruff before writing to disk. If Ruff rejects the config (e.g., due to an unknown key), the sync is aborted and the local file is left unchanged.
+
+```toml
+validate = true
+```
+
+> [!NOTE]
+> Validation requires `ruff` to be available on PATH. If `ruff` is not found, validation is skipped with a warning.
+
+---
+
+### `strict` *(default: `false`)*
+
+When `true`, all validation warnings (Python version mismatches, deprecated rules) are treated as hard failures. Implies `validate = true`.
+
+```toml
+strict = true
+```
+
+---
+
 ## Full Example
 
 ```toml
@@ -120,6 +143,7 @@ branch = "main"
 path = "ruff"
 to = "."
 pre-commit-version-sync = true
+validate = true
 ```
 
 ## CLI Overrides

--- a/docs/ci-integration.md
+++ b/docs/ci-integration.md
@@ -36,6 +36,31 @@ By using `--output-format github`, `ruff-sync` will emit special workflow comman
 
 ![GitHub PR Annotation](assets/github-pr-annotation.png)
 
+#### With Validation
+
+To catch broken or deprecated Ruff configuration during CI, add `--strict` to upgrade validation warnings into failures:
+
+```yaml
+name: "Standards Check"
+
+on:
+  pull_request:
+    branches: [main]
+
+jobs:
+  ruff-sync:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: astral-sh/setup-uv@v5
+      - name: Check Ruff Config
+        run: uvx ruff-sync check --semantic --strict --output-format github
+```
+
+> [!TIP]
+> `--strict` implies `--validate`. You do not need to pass both flags. This will catch deprecated Ruff rules and Python version mismatches in addition to configuration drift.
+
+
 #### Job Summary
 
 In addition to inline annotations, `ruff-sync` writes a structured Markdown report to the GitHub Actions **Job Summary** page. This provides a high-level overview of all drifts detected across the entire run, making it easy to see exactly what needs to be synchronized without scrolling through log files.
@@ -80,7 +105,7 @@ jobs:
       - uses: actions/checkout@v4
       - uses: astral-sh/setup-uv@v5
       - name: Pull upstream
-        run: uvx ruff-sync
+        run: uvx ruff-sync --validate
       - name: Create Pull Request
         uses: peter-evans/create-pull-request@v6
         with:
@@ -150,7 +175,7 @@ See the [Pre-commit Guide](pre-commit.md) for details on using the official hook
 | Code | Meaning |
 |------|----------|
 | **0** | In sync — no drift detected |
-| **1** | Config drift — `[tool.ruff]` values differ from upstream |
+| **1** | Config drift (`check`), validation failure (`pull --validate`), or sync error |
 | **2** | CLI usage error — invalid arguments (reserved by argparse) |
 | **3** | Pre-commit hook drift — use `--pre-commit` flag to enable this check |
 | **4** | Upstream unreachable — HTTP error or network failure |

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -14,6 +14,9 @@
 | `semantic` | `bool` | `false` | Whether `check` should default to semantic matching. |
 | `diff` | `bool` | `true` | Whether `check` should show a diff by default. |
 | `pre-commit-version-sync` | `bool` | `false` | Sync the pre-commit Ruff hook version with the project's Ruff version. |
+| `validate` | `bool` | `false` | Run the merged config through Ruff before writing to disk. Aborts the sync if Ruff rejects the config. |
+| `strict` | `bool` | `false` | Treat validation warnings (version mismatches, deprecated rules) as hard failures. Implies `validate = true`. |
+
 
 ## Exclude Patterns
 
@@ -64,6 +67,22 @@ exclude = ["target-version"]
 
 > [!NOTE]
 > Excluding `target-version` also automatically skips the Python version consistency check otherwise performed during `--validate` or `--strict` runs.
+
+#### Enable validation by default
+
+If you always want the merged config validated before writing, enable it in your configuration:
+
+```toml
+[tool.ruff-sync]
+validate = true
+```
+
+For even stricter enforcement (treat warnings like Python version mismatches and deprecated rules as hard failures):
+
+```toml
+[tool.ruff-sync]
+strict = true  # implies validate = true
+```
 
 #### Sequential merging of multiple sources
 

--- a/docs/examples/advanced-config.toml
+++ b/docs/examples/advanced-config.toml
@@ -13,3 +13,6 @@ exclude = [
 ]
 # Synchronize your .pre-commit-config.yaml with the upstream Ruff version
 pre-commit-version-sync = true
+
+# Validate merged config before writing (catches bad upstream changes)
+validate = true

--- a/docs/index.md
+++ b/docs/index.md
@@ -20,6 +20,7 @@
 * **📥 Efficient Git Support**: Shallow clones and sparse checkouts for fast extraction.
 * **🚀 Zero-Config Bootstrapping**: Use `--init` to scaffold a new project in one command.
 * **✅ CI Ready**: Built-in `check` command with semantic comparison logic.
+* **✅ Config Validation**: Optionally validate merged configs with Ruff before writing. Strict mode catches deprecated rules and Python version mismatches.
 * **🔗 Pre-commit Sync**: Automatically keep your `.pre-commit-config.yaml` Ruff hook version matched with your project's Ruff version.
 * **🦾 Agent Skill**: Includes a built-in AI skill to configure and troubleshoot your `ruff-sync` setup.
 

--- a/docs/pre-commit.md
+++ b/docs/pre-commit.md
@@ -12,7 +12,7 @@ Verifies that your local `pyproject.toml` or `ruff.toml` matches the upstream co
 
 ```yaml
 - repo: https://github.com/Kilo59/ruff-sync
-  rev: v0.1.3  # Use the latest version
+  rev: v0.1.6  # Use the latest version
   hooks:
     - id: ruff-sync-check
 ```
@@ -23,7 +23,7 @@ Automatically pulls and applies the upstream configuration if a drift is detecte
 
 ```yaml
 - repo: https://github.com/Kilo59/ruff-sync
-  rev: v0.1.3  # Use the latest version
+  rev: v0.1.6  # Use the latest version
   hooks:
     - id: ruff-sync-pull
 ```
@@ -40,7 +40,7 @@ The hooks will automatically respect the configuration defined in your `pyprojec
 ```yaml
 repos:
   - repo: https://github.com/Kilo59/ruff-sync
-    rev: v0.1.3
+    rev: v0.1.6
     hooks:
       - id: ruff-sync-check
         # Common arguments:

--- a/docs/pre-defined-configs.md
+++ b/docs/pre-defined-configs.md
@@ -39,7 +39,7 @@ An exhaustive configuration that explicitly enables and documents almost all ava
 
     ```bash
     # Pin to a specific tag or branch
-    ruff-sync https://github.com/Kilo59/ruff-sync --branch v0.1.3 --path configs/kitchen-sink
+    ruff-sync https://github.com/Kilo59/ruff-sync --branch v0.1.6 --path configs/kitchen-sink
     ```
 
 ---
@@ -77,7 +77,7 @@ Tailored specifically for modern, asynchronous web applications. It focuses on p
 
     ```bash
     # Pin to a specific tag or branch
-    ruff-sync https://github.com/Kilo59/ruff-sync --branch v0.1.3 --path configs/fastapi
+    ruff-sync https://github.com/Kilo59/ruff-sync --branch v0.1.6 --path configs/fastapi
     ```
 
 ---
@@ -115,7 +115,7 @@ Optimized for data science workflows, focusing on readability and common pattern
 
     ```bash
     # Pin to a specific tag or branch
-    ruff-sync https://github.com/Kilo59/ruff-sync --branch v0.1.3 --path configs/data-science-engineering
+    ruff-sync https://github.com/Kilo59/ruff-sync --branch v0.1.6 --path configs/data-science-engineering
     ```
 
 ---
@@ -128,7 +128,7 @@ You can set your preferred curated configuration as the default in your `pyproje
 [tool.ruff-sync]
 upstream = "https://github.com/Kilo59/ruff-sync"
 path = "configs/fastapi"
-branch = "main"  # or "v0.1.3" to pin to a specific git tag
+branch = "main"  # or "v0.1.6" to pin to a specific git tag
 ```
 
 ---

--- a/docs/troubleshooting.md
+++ b/docs/troubleshooting.md
@@ -46,6 +46,37 @@ Use the `--exclude` flag to keep your local settings:
 ruff-sync --exclude lint.line-length
 ```
 
+### Validation failed: `ruff` not found
+
+**Warning**: `⚠️  \`ruff\` not found on PATH — skipping Ruff config validation.`
+
+**Solution**: This is a soft warning, not a failure. If you explicitly want validation, ensure `ruff` is installed and available on your PATH. If using `uv`, run `uv pip install ruff` or add it to your project's dependencies.
+
+### Python version mismatch
+
+**Warning**: `⚠️  Version mismatch: upstream [tool.ruff] target-version='py39'...`
+
+**Solution**:
+This means the upstream configuration targets a different Python version than your project's `requires-python`. You have three options:
+
+1. **Update upstream**: Coordinate with your team to update the upstream `target-version`.
+2. **Exclude the key**: Add `target-version` to your `exclude` list to manage it locally.
+3. **Ignore the warning**: In non-strict mode, this is informational only and does not block the sync.
+
+In `--strict` mode, this warning becomes a hard failure. See the [Usage Guide](usage.md#validating-before-writing) for details.
+
+### Deprecated rule detected
+
+**Warning**: `⚠️  Upstream config uses deprecated rule 'XXX'...`
+
+**Solution**:
+The upstream configuration references a Ruff rule that has been deprecated. This often happens when the upstream hasn't been updated after a Ruff version bump.
+
+1. **Update upstream**: Replace the deprecated rule with its successor in the upstream config.
+2. **Ignore the warning**: In non-strict mode, deprecated rules are informational warnings only.
+
+In `--strict` mode, deprecated rules cause a hard failure.
+
 ### Multi-upstream Fetch Failures
 
 **Error**: `❌ <N> upstream fetches failed`
@@ -83,3 +114,15 @@ Yes, if you use a Git SSH URL (e.g., `git@github.com:org/repo.git`), `ruff-sync`
 ### How do I automate this in CI?
 
 See the [CI Integration](ci-integration.md) guide for GitHub Actions and GitLab CI examples.
+
+### Does `--validate` require `ruff` to be installed?
+
+Yes, validation shells out to the `ruff` binary. If `ruff` is not on your `PATH`, validation is silently skipped with a warning. To use validation, ensure Ruff is installed (e.g., via `uv pip install ruff` or as a project dependency).
+
+### What does `--strict` check for?
+
+In addition to the basic config syntax validation from `--validate`, `--strict` upgrades the following warnings to hard failures:
+
+1. **Python version mismatch**: The upstream `target-version` doesn't align with your local `requires-python`.
+2. **Deprecated Ruff rules**: Any rule codes in `lint.select`, `lint.ignore`, `lint.extend-select`, `lint.extend-ignore`, or `lint.extend-fixable` that Ruff reports as deprecated.
+3. **Ruff stderr warnings**: Any warning messages Ruff emits to stderr when parsing the config.

--- a/docs/usage.md
+++ b/docs/usage.md
@@ -189,8 +189,8 @@ ruff-sync [UPSTREAM_URL...] [--to PATH] [--exclude KEY...] [--init] [--pre-commi
 * **`--exclude KEY...`**: Dotted paths of keys to keep local and never overwrite (e.g., `lint.isort`).
 * **`--init`**: Create a new `pyproject.toml` with the upstream configuration if it doesn't already exist. This automatically saves the upstream source and any other CLI flags into the `[tool.ruff-sync]` section.
 * **`--save` / `--no-save`**: Force serialization (or prevent serialization) of the provided CLI arguments (like `upstream`, `exclude`, etc.) directly into the `[tool.ruff-sync]` section of the target `pyproject.toml` for future use. Note: any credentials present in the upstream URL will cause this operation to safely abort.
-* **`--validate`**: Run the merged config through Ruff before writing to disk. If Ruff rejects the config (e.g., due to an unknown key), the sync is aborted and the local file is left unchanged. Off by default to avoid adding latency and an implicit dependency on `ruff` being present in `PATH`.
-* **`--strict`**: Treat validation warnings (such as Python version mismatches or deprecated rules) as hard failures. Implies `--validate` — you do not need to pass both flags.
+* **`--validate` / `--no-validate`**: Run the merged config through Ruff before writing to disk. If Ruff rejects the config (e.g., due to an unknown key), the sync is aborted and the local file is left unchanged. Off by default. Use `--no-validate` to explicitly disable validation even if `validate = true` is set in your config.
+* **`--strict` / `--no-strict`**: Treat validation warnings (such as Python version mismatches or deprecated rules) as hard failures. Implies `--validate` — you do not need to pass both flags. Use `--no-strict` to explicitly disable strict mode even if `strict = true` is in config.
 * **`--output-format [text|json|github|gitlab|sarif]`**: Specify the output format for synchronization results.
     - `text` (default): Human-readable terminal output.
     - `json`: Machine-readable JSON output for tool integration.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "ruff-sync"
-version = "0.1.6.dev3"
+version = "0.1.6.dev4"
 description = "Synchronize Ruff linter configuration across projects"
 keywords = ["ruff", "linter", "config", "synchronize", "python", "linting", "automation", "tomlkit", "pre-commit"]
 authors = [

--- a/src/ruff_sync/cli.py
+++ b/src/ruff_sync/cli.py
@@ -35,6 +35,7 @@ from ruff_sync.constants import (
     ConfKey,
     MissingType,
     OutputFormat,
+    apply_bool_precedence,
 )
 from ruff_sync.core import (
     Config,
@@ -555,19 +556,10 @@ def _resolve_validate(args: CLIArguments, config: Config) -> bool | MissingType:
     if args.validate is not None:
         return args.validate
 
-    # CLI --strict flag wins if it's explicitly True (implies validate=True)
-    if args.strict is True:
-        return True
-
     # Fallback to config
     validate_attr = ConfKey.to_attr(ConfKey.VALIDATE)
     if validate_attr in config:
         return bool(config[validate_attr])  # type: ignore[literal-required]
-
-    # Special case: config 'strict = true' also implies 'validate = true'
-    strict_attr = ConfKey.to_attr(ConfKey.STRICT)
-    if strict_attr in config:
-        return bool(config[strict_attr])  # type: ignore[literal-required]
 
     return MISSING
 
@@ -692,6 +684,12 @@ def main() -> int:
         resolve_raw_url(u, branch=resolved.branch, path=resolved.path) for u in resolved.upstream
     )
 
+    # Resolve validation flags with prioritized CLI vs Config rules,
+    # then apply bitdirectional implications (strict -> validate, !validate -> !strict)
+    raw_validate = _resolve_validate(args, config)
+    raw_strict = _resolve_strict(args, config)
+    validate, strict = apply_bool_precedence(raw_validate, raw_strict)
+
     exec_args = Arguments(
         command=args.command,
         upstream=resolved_upstream,
@@ -706,8 +704,8 @@ def main() -> int:
         pre_commit=_resolve_pre_commit(args, config),
         save=getattr(args, "save", None),
         output_format=resolved.output_format,
-        validate=_resolve_validate(args, config),
-        strict=_resolve_strict(args, config),
+        validate=validate,
+        strict=strict,
     )
 
     # Warn if the specified output format doesn't match the current CI environment

--- a/src/ruff_sync/cli.py
+++ b/src/ruff_sync/cli.py
@@ -35,7 +35,6 @@ from ruff_sync.constants import (
     ConfKey,
     MissingType,
     OutputFormat,
-    apply_bool_precedence,
 )
 from ruff_sync.core import (
     Config,
@@ -551,10 +550,20 @@ def _resolve_to(args: CLIArguments, config: Config, initial_to: pathlib.Path) ->
 
 
 def _resolve_validate(args: CLIArguments, config: Config) -> bool | MissingType:
-    """Resolve validation setting from CLI or config."""
+    """Resolve validation setting from CLI or config.
+
+    If ``--strict`` was explicitly set at the CLI level, it implies ``--validate``.
+    This prevents ``validate = false`` in config from silently neutralising a
+    CLI ``--strict`` flag.
+    """
     # CLI --validate flag wins if explicitly provided
     if args.validate is not None:
         return args.validate
+
+    # If --strict was explicitly passed via CLI, it implies validate=True
+    # even when config sets `validate = false`.
+    if args.strict is True:
+        return True
 
     # Fallback to config
     validate_attr = ConfKey.to_attr(ConfKey.VALIDATE)
@@ -684,11 +693,11 @@ def main() -> int:
         resolve_raw_url(u, branch=resolved.branch, path=resolved.path) for u in resolved.upstream
     )
 
-    # Resolve validation flags with prioritized CLI vs Config rules,
-    # then apply bitdirectional implications (strict -> validate, !validate -> !strict)
+    # Resolve validation flags from CLI (with CLI --strict implying validate=True)
+    # and fall back to config. Bidirectional implications are handled by
+    # resolve_bool_flags() inside Arguments.resolve(), so we store raw sentinels here.
     raw_validate = _resolve_validate(args, config)
     raw_strict = _resolve_strict(args, config)
-    validate, strict = apply_bool_precedence(raw_validate, raw_strict)
 
     exec_args = Arguments(
         command=args.command,
@@ -704,8 +713,8 @@ def main() -> int:
         pre_commit=_resolve_pre_commit(args, config),
         save=getattr(args, "save", None),
         output_format=resolved.output_format,
-        validate=validate,
-        strict=strict,
+        validate=raw_validate,
+        strict=raw_strict,
     )
 
     # Warn if the specified output format doesn't match the current CI environment

--- a/src/ruff_sync/cli.py
+++ b/src/ruff_sync/cli.py
@@ -125,6 +125,53 @@ class Arguments(NamedTuple):
         """Return the set of all field names, including deprecated ones."""
         return set(cls._fields) | {"source"}
 
+    def resolve(self) -> ExecutionArgs:
+        """Resolve all MISSING sentinels to their effective defaults for execution."""
+        from ruff_sync.constants import resolve_bool_flags  # noqa: PLC0415
+
+        eff_validate, eff_strict, eff_pre_commit = resolve_bool_flags(
+            self.validate,
+            self.strict,
+            self.pre_commit,
+        )
+        return ExecutionArgs(
+            command=self.command,
+            upstream=self.upstream,
+            to=self.to,
+            exclude=self.exclude,
+            verbose=self.verbose,
+            branch=self.branch,
+            path=self.path,
+            semantic=self.semantic,
+            diff=self.diff,
+            init=self.init,
+            pre_commit=eff_pre_commit,
+            save=self.save,
+            output_format=self.output_format,
+            validate=eff_validate,
+            strict=eff_strict,
+        )
+
+
+class ExecutionArgs(NamedTuple):
+    """Resolved arguments for execution logic — all sentinels replaced with concrete values."""
+
+    command: str
+    upstream: tuple[URL, ...]
+    to: pathlib.Path
+    exclude: Iterable[str]
+    verbose: int
+    branch: str
+    path: str | None
+    semantic: bool
+    diff: bool
+    init: bool
+    pre_commit: bool  # plain bool — MISSING resolved to default
+    save: bool | None
+    output_format: OutputFormat
+    validate: bool  # plain bool — MISSING resolved to default
+    strict: bool  # plain bool — MISSING resolved to default
+
 
 class ResolvedArgs(NamedTuple):
     """Internal container for resolved arguments."""
@@ -135,9 +182,6 @@ class ResolvedArgs(NamedTuple):
     branch: str
     path: str | None
     output_format: OutputFormat
-    validate: bool | MissingType
-    strict: bool | MissingType
-    pre_commit: bool | MissingType
 
 
 class CLIArguments(Protocol):
@@ -550,9 +594,6 @@ def _resolve_args(args: CLIArguments, config: Config, initial_to: pathlib.Path) 
     branch = _resolve_branch(args, config)
     path = _resolve_path(args, config)
     output_format = _resolve_output_format(args, config)
-    validate = _resolve_validate(args, config)
-    strict = _resolve_strict(args, config)
-    pre_commit = _resolve_pre_commit(args, config)
 
     # Normalize path "" -> None to match core expectation
     final_path: str | None = path or None
@@ -564,9 +605,6 @@ def _resolve_args(args: CLIArguments, config: Config, initial_to: pathlib.Path) 
         branch,
         final_path,
         output_format,
-        validate,
-        strict,
-        pre_commit,
     )
 
 
@@ -665,11 +703,11 @@ def main() -> int:
         semantic=getattr(args, "semantic", False),
         diff=getattr(args, "diff", True),
         init=getattr(args, "init", False),
-        pre_commit=resolved.pre_commit,
+        pre_commit=_resolve_pre_commit(args, config),
         save=getattr(args, "save", None),
         output_format=resolved.output_format,
-        validate=resolved.validate,
-        strict=resolved.strict,
+        validate=_resolve_validate(args, config),
+        strict=_resolve_strict(args, config),
     )
 
     # Warn if the specified output format doesn't match the current CI environment

--- a/src/ruff_sync/cli.py
+++ b/src/ruff_sync/cli.py
@@ -31,7 +31,9 @@ from ruff_sync.constants import (
     DEFAULT_BRANCH,
     DEFAULT_EXCLUDE,
     DEFAULT_PATH,
+    MISSING,
     ConfKey,
+    MissingType,
     OutputFormat,
 )
 from ruff_sync.core import (
@@ -105,11 +107,11 @@ class Arguments(NamedTuple):
     semantic: bool = False
     diff: bool = True
     init: bool = False
-    pre_commit: bool = False
+    pre_commit: bool | MissingType = MISSING
     save: bool | None = None
     output_format: OutputFormat = OutputFormat.TEXT
-    validate: bool = False  # run --validate checks before writing
-    strict: bool = False  # treat warnings as errors (implies --validate)
+    validate: bool | MissingType = MISSING  # run --validate checks before writing
+    strict: bool | MissingType = MISSING  # treat warnings as errors (implies --validate)
 
     @property
     @deprecated("Use 'to' instead")
@@ -133,8 +135,9 @@ class ResolvedArgs(NamedTuple):
     branch: str
     path: str | None
     output_format: OutputFormat
-    validate: bool
-    strict: bool
+    validate: bool | MissingType
+    strict: bool | MissingType
+    pre_commit: bool | MissingType
 
 
 class CLIArguments(Protocol):
@@ -155,8 +158,8 @@ class CLIArguments(Protocol):
     save: bool | None
     semantic: bool
     diff: bool
-    validate: bool
-    strict: bool
+    validate: bool | None
+    strict: bool | None
 
 
 @lru_cache(maxsize=1)
@@ -298,8 +301,8 @@ def _get_cli_parser() -> ArgumentParser:
     )
     common_parser.add_argument(
         "--validate",
-        action="store_true",
-        default=False,
+        action=BooleanOptionalAction,
+        default=None,
         help=(
             "Validate the merged config with Ruff before writing to disk. "
             "Aborts if Ruff rejects the config. Off by default."
@@ -307,8 +310,8 @@ def _get_cli_parser() -> ArgumentParser:
     )
     common_parser.add_argument(
         "--strict",
-        action="store_true",
-        default=False,
+        action=BooleanOptionalAction,
+        default=None,
         help=(
             "Treat all validation warnings as hard failures. Implies --validate. "
             "Aborts if any version mismatch or deprecated rule is detected."
@@ -502,20 +505,41 @@ def _resolve_to(args: CLIArguments, config: Config, initial_to: pathlib.Path) ->
     return initial_to
 
 
-def _resolve_validate(args: CLIArguments, config: Config) -> bool:
+def _resolve_validate(args: CLIArguments, config: Config) -> bool | MissingType:
     """Resolve validation setting from CLI or config."""
-    # CLI flag --strict or --validate always wins
-    if args.strict or args.validate:
+    # CLI --validate flag wins if explicitly provided
+    if args.validate is not None:
+        return args.validate
+
+    # CLI --strict flag wins if it's explicitly True (implies validate=True)
+    if args.strict is True:
         return True
-    return bool(config.get("validate", False))
+
+    # Fallback to config
+    validate_attr = ConfKey.to_attr(ConfKey.VALIDATE)
+    if validate_attr in config:
+        return bool(config[validate_attr])  # type: ignore[literal-required]
+
+    # Special case: config 'strict = true' also implies 'validate = true'
+    strict_attr = ConfKey.to_attr(ConfKey.STRICT)
+    if strict_attr in config:
+        return bool(config[strict_attr])  # type: ignore[literal-required]
+
+    return MISSING
 
 
-def _resolve_strict(args: CLIArguments, config: Config) -> bool:
+def _resolve_strict(args: CLIArguments, config: Config) -> bool | MissingType:
     """Resolve strict setting from CLI or config."""
     # CLI flag --strict always wins
-    if args.strict:
-        return True
-    return bool(config.get("strict", False))
+    if args.strict is not None:
+        return args.strict
+
+    # Fallback to config
+    attr = ConfKey.to_attr(ConfKey.STRICT)
+    if attr in config:
+        return bool(config[attr])  # type: ignore[literal-required]
+
+    return MISSING
 
 
 def _resolve_args(args: CLIArguments, config: Config, initial_to: pathlib.Path) -> ResolvedArgs:
@@ -528,6 +552,7 @@ def _resolve_args(args: CLIArguments, config: Config, initial_to: pathlib.Path) 
     output_format = _resolve_output_format(args, config)
     validate = _resolve_validate(args, config)
     strict = _resolve_strict(args, config)
+    pre_commit = _resolve_pre_commit(args, config)
 
     # Normalize path "" -> None to match core expectation
     final_path: str | None = path or None
@@ -539,12 +564,13 @@ def _resolve_args(args: CLIArguments, config: Config, initial_to: pathlib.Path) 
         branch,
         final_path,
         output_format,
-        validate or strict,  # strict implies validate
+        validate,
         strict,
+        pre_commit,
     )
 
 
-def _resolve_pre_commit(args: CLIArguments, config: Config) -> bool:
+def _resolve_pre_commit(args: CLIArguments, config: Config) -> bool | MissingType:
     """Resolve pre-commit sync setting from CLI or config."""
     if args.pre_commit is not None:
         return args.pre_commit
@@ -553,7 +579,7 @@ def _resolve_pre_commit(args: CLIArguments, config: Config) -> bool:
     if pre_commit_attr in config:
         val = config.get(pre_commit_attr)
         return bool(val)
-    return False
+    return MISSING
 
 
 def _detect_ci_provider() -> CIProvider | None:
@@ -621,29 +647,29 @@ def main() -> int:
     initial_to = pathlib.Path(arg_to) if arg_to else pathlib.Path()
     config: Config = get_config(initial_to)
 
-    upstream, to_val, exclude, branch, path, output_format, validate, strict = _resolve_args(
-        args, config, initial_to
-    )
-    pre_commit_val = _resolve_pre_commit(args, config)
+    # Resolve all arguments (honoring CLI overrides over config values)
+    resolved = _resolve_args(args, config, initial_to)
 
-    resolved_upstream = tuple(resolve_raw_url(u, branch=branch, path=path) for u in upstream)
+    resolved_upstream = tuple(
+        resolve_raw_url(u, branch=resolved.branch, path=resolved.path) for u in resolved.upstream
+    )
 
     exec_args = Arguments(
         command=args.command,
         upstream=resolved_upstream,
-        to=to_val,
-        exclude=exclude,
+        to=resolved.to,
+        exclude=resolved.exclude,
         verbose=args.verbose,
-        branch=branch,
-        path=path,
+        branch=resolved.branch,
+        path=resolved.path,
         semantic=getattr(args, "semantic", False),
         diff=getattr(args, "diff", True),
         init=getattr(args, "init", False),
-        pre_commit=pre_commit_val,
+        pre_commit=resolved.pre_commit,
         save=getattr(args, "save", None),
-        output_format=output_format,
-        validate=validate,
-        strict=strict,
+        output_format=resolved.output_format,
+        validate=resolved.validate,
+        strict=resolved.strict,
     )
 
     # Warn if the specified output format doesn't match the current CI environment

--- a/src/ruff_sync/cli.py
+++ b/src/ruff_sync/cli.py
@@ -133,6 +133,8 @@ class ResolvedArgs(NamedTuple):
     branch: str
     path: str | None
     output_format: OutputFormat
+    validate: bool
+    strict: bool
 
 
 class CLIArguments(Protocol):
@@ -500,6 +502,22 @@ def _resolve_to(args: CLIArguments, config: Config, initial_to: pathlib.Path) ->
     return initial_to
 
 
+def _resolve_validate(args: CLIArguments, config: Config) -> bool:
+    """Resolve validation setting from CLI or config."""
+    # CLI flag --strict or --validate always wins
+    if args.strict or args.validate:
+        return True
+    return bool(config.get("validate", False))
+
+
+def _resolve_strict(args: CLIArguments, config: Config) -> bool:
+    """Resolve strict setting from CLI or config."""
+    # CLI flag --strict always wins
+    if args.strict:
+        return True
+    return bool(config.get("strict", False))
+
+
 def _resolve_args(args: CLIArguments, config: Config, initial_to: pathlib.Path) -> ResolvedArgs:
     """Resolve upstream, to, exclude, branch, and path from CLI and config."""
     upstream = _resolve_upstream(args, config)
@@ -508,6 +526,8 @@ def _resolve_args(args: CLIArguments, config: Config, initial_to: pathlib.Path) 
     branch = _resolve_branch(args, config)
     path = _resolve_path(args, config)
     output_format = _resolve_output_format(args, config)
+    validate = _resolve_validate(args, config)
+    strict = _resolve_strict(args, config)
 
     # Normalize path "" -> None to match core expectation
     final_path: str | None = path or None
@@ -519,6 +539,8 @@ def _resolve_args(args: CLIArguments, config: Config, initial_to: pathlib.Path) 
         branch,
         final_path,
         output_format,
+        validate or strict,  # strict implies validate
+        strict,
     )
 
 
@@ -599,7 +621,9 @@ def main() -> int:
     initial_to = pathlib.Path(arg_to) if arg_to else pathlib.Path()
     config: Config = get_config(initial_to)
 
-    upstream, to_val, exclude, branch, path, output_format = _resolve_args(args, config, initial_to)
+    upstream, to_val, exclude, branch, path, output_format, validate, strict = _resolve_args(
+        args, config, initial_to
+    )
     pre_commit_val = _resolve_pre_commit(args, config)
 
     resolved_upstream = tuple(resolve_raw_url(u, branch=branch, path=path) for u in upstream)
@@ -618,9 +642,8 @@ def main() -> int:
         pre_commit=pre_commit_val,
         save=getattr(args, "save", None),
         output_format=output_format,
-        # --strict implies --validate
-        validate=getattr(args, "validate", False) or getattr(args, "strict", False),
-        strict=getattr(args, "strict", False),
+        validate=validate,
+        strict=strict,
     )
 
     # Warn if the specified output format doesn't match the current CI environment

--- a/src/ruff_sync/cli.py
+++ b/src/ruff_sync/cli.py
@@ -296,6 +296,24 @@ def _get_cli_parser() -> ArgumentParser:
         default=None,
         help="Format for output. Default: text (auto-detected in CI).",
     )
+    common_parser.add_argument(
+        "--validate",
+        action="store_true",
+        default=False,
+        help=(
+            "Validate the merged config with Ruff before writing to disk. "
+            "Aborts if Ruff rejects the config. Off by default."
+        ),
+    )
+    common_parser.add_argument(
+        "--strict",
+        action="store_true",
+        default=False,
+        help=(
+            "Treat all validation warnings as hard failures. Implies --validate. "
+            "Aborts if any version mismatch or deprecated rule is detected."
+        ),
+    )
 
     # Pull subcommand (the default action)
     pull_parser = subparsers.add_parser(
@@ -313,24 +331,6 @@ def _get_cli_parser() -> ArgumentParser:
         action=BooleanOptionalAction,
         default=None,
         help="Save CLI arguments to [tool.ruff-sync] in pyproject.toml.",
-    )
-    pull_parser.add_argument(
-        "--validate",
-        action="store_true",
-        default=False,
-        help=(
-            "Validate the merged config with Ruff before writing to disk. "
-            "Aborts if Ruff rejects the config. Off by default."
-        ),
-    )
-    pull_parser.add_argument(
-        "--strict",
-        action="store_true",
-        default=False,
-        help=(
-            "Treat all validation warnings as hard failures. Implies --validate. "
-            "Aborts if any version mismatch or deprecated rule is detected."
-        ),
     )
 
     # Check subcommand

--- a/src/ruff_sync/constants.py
+++ b/src/ruff_sync/constants.py
@@ -131,25 +131,19 @@ def resolve_defaults(
     branch: str | MissingType,
     path: str | None | MissingType,
     exclude: Iterable[str] | MissingType,
-    validate: bool | MissingType = MISSING,
-    strict: bool | MissingType = MISSING,
-    pre_commit: bool | MissingType = MISSING,
-) -> tuple[str, str | None, Iterable[str], bool, bool, bool]:
+) -> tuple[str, str | None, Iterable[str]]:
     """Resolve MISSING sentinel values to their effective defaults.
 
-    This is the single source of truth for MISSING → default resolution across
-    the CLI and internal logic, keeping the layers in sync.
+    This is the single source of truth for MISSING → default resolution for
+    URL-related parameters (branch, path, exclude).
 
     Args:
         branch: The resolved branch value or ``MISSING``.
         path: The resolved path value or ``MISSING``.
         exclude: The resolved exclude iterable or ``MISSING``.
-        validate: The resolved validate flag or ``MISSING``.
-        strict: The resolved strict flag or ``MISSING``.
-        pre_commit: The resolved pre_commit flag or ``MISSING``.
 
     Returns:
-        A ``(branch, path, exclude, validate, strict, pre_commit)`` tuple with defaults applied.
+        A ``(branch, path, exclude)`` tuple with defaults applied.
         ``path`` is normalised to ``None`` (not ``""``) so callers can forward
         it directly to :func:`~ruff_sync.core.resolve_raw_url`.
     """
@@ -160,9 +154,23 @@ def resolve_defaults(
     eff_path: str | None = raw_path or None
     eff_exclude = exclude if exclude is not MISSING else DEFAULT_EXCLUDE
 
+    return eff_branch, eff_path, eff_exclude
+
+
+def resolve_bool_flags(
+    validate: bool | MissingType = MISSING,
+    strict: bool | MissingType = MISSING,
+    pre_commit: bool | MissingType = MISSING,
+) -> tuple[bool, bool, bool]:
+    """Resolve MISSING sentinel values for boolean execution flags.
+
+    Returns:
+        A ``(validate, strict, pre_commit)`` tuple with defaults applied.
+        ``strict=True`` implicitly enables ``validate``.
+    """
     eff_strict = strict if strict is not MISSING else False
     # strict mode implicitly enables validation
     eff_validate = (validate if validate is not MISSING else False) or eff_strict
     eff_pre_commit = pre_commit if pre_commit is not MISSING else True
 
-    return eff_branch, eff_path, eff_exclude, eff_validate, eff_strict, eff_pre_commit
+    return eff_validate, eff_strict, eff_pre_commit

--- a/src/ruff_sync/constants.py
+++ b/src/ruff_sync/constants.py
@@ -157,6 +157,21 @@ def resolve_defaults(
     return eff_branch, eff_path, eff_exclude
 
 
+def apply_bool_precedence(
+    validate: bool | MissingType, strict: bool | MissingType
+) -> tuple[bool | MissingType, bool | MissingType]:
+    """Apply precedence rules for validate and strict flags.
+
+    1. Disabling validation implicitly disables strict mode.
+    2. Strict mode implicitly enables validation.
+    """
+    if validate is False:
+        strict = False
+    elif strict is True:
+        validate = True
+    return validate, strict
+
+
 def resolve_bool_flags(
     validate: bool | MissingType = MISSING,
     strict: bool | MissingType = MISSING,
@@ -168,9 +183,10 @@ def resolve_bool_flags(
         A ``(validate, strict, pre_commit)`` tuple with defaults applied.
         ``strict=True`` implicitly enables ``validate``.
     """
+    validate, strict = apply_bool_precedence(validate, strict)
+
+    eff_validate = validate if validate is not MISSING else False
     eff_strict = strict if strict is not MISSING else False
-    # strict mode implicitly enables validation
-    eff_validate = (validate if validate is not MISSING else False) or eff_strict
-    eff_pre_commit = pre_commit if pre_commit is not MISSING else True
+    eff_pre_commit = pre_commit if pre_commit is not MISSING else False
 
     return eff_validate, eff_strict, eff_pre_commit

--- a/src/ruff_sync/constants.py
+++ b/src/ruff_sync/constants.py
@@ -81,6 +81,8 @@ class ConfKey(str, enum.Enum):
     INIT = "init"
     SAVE = "save"
     VERBOSE = "verbose"
+    VALIDATE = "validate"
+    STRICT = "strict"
 
     # Legacy / Alias Keys
     SOURCE = "source"  # Legacy for 'to'

--- a/src/ruff_sync/constants.py
+++ b/src/ruff_sync/constants.py
@@ -129,9 +129,12 @@ class ConfKey(str, enum.Enum):
 
 def resolve_defaults(
     branch: str | MissingType,
-    path: str | MissingType,
+    path: str | None | MissingType,
     exclude: Iterable[str] | MissingType,
-) -> tuple[str, str | None, Iterable[str]]:
+    validate: bool | MissingType = MISSING,
+    strict: bool | MissingType = MISSING,
+    pre_commit: bool | MissingType = MISSING,
+) -> tuple[str, str | None, Iterable[str], bool, bool, bool]:
     """Resolve MISSING sentinel values to their effective defaults.
 
     This is the single source of truth for MISSING → default resolution across
@@ -141,9 +144,12 @@ def resolve_defaults(
         branch: The resolved branch value or ``MISSING``.
         path: The resolved path value or ``MISSING``.
         exclude: The resolved exclude iterable or ``MISSING``.
+        validate: The resolved validate flag or ``MISSING``.
+        strict: The resolved strict flag or ``MISSING``.
+        pre_commit: The resolved pre_commit flag or ``MISSING``.
 
     Returns:
-        A ``(branch, path, exclude)`` tuple with defaults applied.
+        A ``(branch, path, exclude, validate, strict, pre_commit)`` tuple with defaults applied.
         ``path`` is normalised to ``None`` (not ``""``) so callers can forward
         it directly to :func:`~ruff_sync.core.resolve_raw_url`.
     """
@@ -153,4 +159,10 @@ def resolve_defaults(
     # but explicit None is the canonical "root directory" sentinel.
     eff_path: str | None = raw_path or None
     eff_exclude = exclude if exclude is not MISSING else DEFAULT_EXCLUDE
-    return eff_branch, eff_path, eff_exclude
+
+    eff_strict = strict if strict is not MISSING else False
+    # strict mode implicitly enables validation
+    eff_validate = (validate if validate is not MISSING else False) or eff_strict
+    eff_pre_commit = pre_commit if pre_commit is not MISSING else True
+
+    return eff_branch, eff_path, eff_exclude, eff_validate, eff_strict, eff_pre_commit

--- a/src/ruff_sync/core.py
+++ b/src/ruff_sync/core.py
@@ -946,7 +946,7 @@ async def check(
         >>> # asyncio.run(check(args))
     """
     # Resolve defaults for execution logic
-    exec = args.resolve()
+    exec_args = args.resolve()
 
     output_format = args.output_format
     fmt: ResultFormatter = get_formatter(output_format)
@@ -974,7 +974,7 @@ async def check(
             merged_doc = await _merge_multiple_upstreams(
                 merged_doc,
                 is_target_ruff_toml=is_ruff_toml_file(_source_toml_path.name),
-                args=exec,
+                args=exec_args,
                 client=client,
             )
 
@@ -995,13 +995,13 @@ async def check(
 
             if source_val == merged_val:
                 fmt.success("✅ Ruff configuration is semantically in sync.")
-                exit_code = _check_pre_commit_sync(exec.pre_commit, fmt)
+                exit_code = _check_pre_commit_sync(exec_args.pre_commit, fmt)
                 if exit_code is not None:
                     return exit_code
                 return 0
         elif source_doc.as_string() == merged_doc.as_string():
             fmt.success("✅ Ruff configuration is in sync.")
-            exit_code = _check_pre_commit_sync(exec.pre_commit, fmt)
+            exit_code = _check_pre_commit_sync(exec_args.pre_commit, fmt)
             if exit_code is not None:
                 return exit_code
             return 0
@@ -1134,7 +1134,7 @@ async def pull(
         >>> # asyncio.run(pull(args))
     """
     # Resolve defaults for execution logic
-    exec = args.resolve()
+    exec_args = args.resolve()
 
     output_format = args.output_format
     fmt = get_formatter(output_format)
@@ -1168,17 +1168,20 @@ async def pull(
             source_doc = await _merge_multiple_upstreams(
                 source_doc,
                 is_target_ruff_toml=is_ruff_toml_file(_source_toml_path.name),
-                args=exec,
+                args=exec_args,
                 client=client,
             )
 
         # Validation is opt-in — only run if --validate (or --strict) was passed
-        if exec.validate:
+        if exec_args.validate:
             from ruff_sync.validation import validate_merged_config  # noqa: PLC0415
 
             is_ruff_toml = is_ruff_toml_file(_source_toml_path.name)
             if not validate_merged_config(
-                source_doc, is_ruff_toml=is_ruff_toml, strict=exec.strict, exclude=exec.exclude
+                source_doc,
+                is_ruff_toml=is_ruff_toml,
+                strict=exec_args.strict,
+                exclude=exec_args.exclude,
             ):
                 fmt.error(
                     "❌ Merged config failed validation. Local file left unchanged.",
@@ -1204,7 +1207,7 @@ async def pull(
             rel_path = _source_toml_path.resolve()
         fmt.success(f"✅ Updated {rel_path}")
 
-        if exec.pre_commit:
+        if exec_args.pre_commit:
             sync_pre_commit(pathlib.Path.cwd(), dry_run=False)
 
         return 0

--- a/src/ruff_sync/core.py
+++ b/src/ruff_sync/core.py
@@ -123,6 +123,8 @@ class Config(TypedDict, total=False):
     init: bool
     pre_commit_version_sync: bool
     output_format: str
+    validate: bool
+    strict: bool
 
 
 def _resolve_upstream_target_path(path: str | None) -> str:
@@ -1096,8 +1098,14 @@ def serialize_ruff_sync_config(doc: TOMLDocument, args: Arguments) -> None:
     if args.path != DEFAULT_PATH and args.path is not None:
         ruff_sync_table[ConfKey.PATH] = args.path
 
-    if args.pre_commit:
-        ruff_sync_table[ConfKey.PRE_COMMIT_VERSION_SYNC] = args.pre_commit
+    # Simple boolean flags
+    for key, attr in [
+        (ConfKey.PRE_COMMIT_VERSION_SYNC, "pre_commit"),
+        (ConfKey.VALIDATE, "validate"),
+        (ConfKey.STRICT, "strict"),
+    ]:
+        if getattr(args, attr, False):
+            ruff_sync_table[key] = True
 
 
 async def pull(

--- a/src/ruff_sync/core.py
+++ b/src/ruff_sync/core.py
@@ -36,7 +36,6 @@ from ruff_sync.constants import (
     DEFAULT_PATH,
     MISSING,
     ConfKey,
-    resolve_defaults,
 )
 from ruff_sync.formatters import ResultFormatter, get_formatter
 from ruff_sync.pre_commit import sync_pre_commit
@@ -44,7 +43,7 @@ from ruff_sync.pre_commit import sync_pre_commit
 if TYPE_CHECKING:
     from tomlkit.container import Container
 
-    from ruff_sync.cli import Arguments
+    from ruff_sync.cli import Arguments, ExecutionArgs
 
 __all__: Final[list[str]] = [
     "Config",
@@ -747,7 +746,7 @@ async def fetch_upstreams_concurrently(
 async def _merge_multiple_upstreams(
     target_doc: TOMLDocument,
     is_target_ruff_toml: bool,
-    args: Arguments,
+    args: ExecutionArgs,
     client: httpx.AsyncClient,
 ) -> TOMLDocument:
     """Fetch and merge all upstreams into the target document.
@@ -755,15 +754,8 @@ async def _merge_multiple_upstreams(
     Downloads are performed concurrently via fetch_upstreams_concurrently,
     while merging remains sequential to preserve layering order.
     """
-    # Resolve defaults for internal logic using the single source of truth
-    res_branch, res_path, res_exclude, _, _, _ = resolve_defaults(
-        args.branch,
-        args.path,
-        args.exclude,
-    )
-
     fetch_results = await fetch_upstreams_concurrently(
-        args.upstream, client, branch=res_branch, path=res_path
+        args.upstream, client, branch=args.branch, path=args.path
     )
 
     # Sequentially merge the results in the original order
@@ -776,7 +768,7 @@ async def _merge_multiple_upstreams(
             fetch_result.buffer.read(),
             is_ruff_toml=is_upstream_ruff_toml,
             create_if_missing=False,
-            exclude=res_exclude,
+            exclude=args.exclude,
         )
 
         target_doc = merge_ruff_toml(
@@ -954,21 +946,7 @@ async def check(
         >>> # asyncio.run(check(args))
     """
     # Resolve defaults for execution logic
-    (
-        _res_branch,
-        _res_path,
-        _res_exclude,
-        _res_validate,
-        _res_strict,
-        res_pre_commit,
-    ) = resolve_defaults(
-        args.branch,
-        args.path,
-        args.exclude,
-        args.validate,
-        args.strict,
-        args.pre_commit,
-    )
+    exec = args.resolve()
 
     output_format = args.output_format
     fmt: ResultFormatter = get_formatter(output_format)
@@ -996,7 +974,7 @@ async def check(
             merged_doc = await _merge_multiple_upstreams(
                 merged_doc,
                 is_target_ruff_toml=is_ruff_toml_file(_source_toml_path.name),
-                args=args,
+                args=exec,
                 client=client,
             )
 
@@ -1017,13 +995,13 @@ async def check(
 
             if source_val == merged_val:
                 fmt.success("✅ Ruff configuration is semantically in sync.")
-                exit_code = _check_pre_commit_sync(res_pre_commit, fmt)
+                exit_code = _check_pre_commit_sync(exec.pre_commit, fmt)
                 if exit_code is not None:
                     return exit_code
                 return 0
         elif source_doc.as_string() == merged_doc.as_string():
             fmt.success("✅ Ruff configuration is in sync.")
-            exit_code = _check_pre_commit_sync(res_pre_commit, fmt)
+            exit_code = _check_pre_commit_sync(exec.pre_commit, fmt)
             if exit_code is not None:
                 return exit_code
             return 0
@@ -1156,21 +1134,7 @@ async def pull(
         >>> # asyncio.run(pull(args))
     """
     # Resolve defaults for execution logic
-    (
-        _res_branch,
-        _res_path,
-        res_exclude,
-        res_validate,
-        res_strict,
-        res_pre_commit,
-    ) = resolve_defaults(
-        args.branch,
-        args.path,
-        args.exclude,
-        args.validate,
-        args.strict,
-        args.pre_commit,
-    )
+    exec = args.resolve()
 
     output_format = args.output_format
     fmt = get_formatter(output_format)
@@ -1204,17 +1168,17 @@ async def pull(
             source_doc = await _merge_multiple_upstreams(
                 source_doc,
                 is_target_ruff_toml=is_ruff_toml_file(_source_toml_path.name),
-                args=args,
+                args=exec,
                 client=client,
             )
 
         # Validation is opt-in — only run if --validate (or --strict) was passed
-        if res_validate:
+        if exec.validate:
             from ruff_sync.validation import validate_merged_config  # noqa: PLC0415
 
             is_ruff_toml = is_ruff_toml_file(_source_toml_path.name)
             if not validate_merged_config(
-                source_doc, is_ruff_toml=is_ruff_toml, strict=res_strict, exclude=res_exclude
+                source_doc, is_ruff_toml=is_ruff_toml, strict=exec.strict, exclude=exec.exclude
             ):
                 fmt.error(
                     "❌ Merged config failed validation. Local file left unchanged.",
@@ -1240,7 +1204,7 @@ async def pull(
             rel_path = _source_toml_path.resolve()
         fmt.success(f"✅ Updated {rel_path}")
 
-        if res_pre_commit:
+        if exec.pre_commit:
             sync_pre_commit(pathlib.Path.cwd(), dry_run=False)
 
         return 0

--- a/src/ruff_sync/core.py
+++ b/src/ruff_sync/core.py
@@ -34,7 +34,9 @@ from ruff_sync.constants import (
     DEFAULT_BRANCH,
     DEFAULT_EXCLUDE,
     DEFAULT_PATH,
+    MISSING,
     ConfKey,
+    resolve_defaults,
 )
 from ruff_sync.formatters import ResultFormatter, get_formatter
 from ruff_sync.pre_commit import sync_pre_commit
@@ -753,10 +755,15 @@ async def _merge_multiple_upstreams(
     Downloads are performed concurrently via fetch_upstreams_concurrently,
     while merging remains sequential to preserve layering order.
     """
-    branch, path, exclude = args.branch, args.path, args.exclude
+    # Resolve defaults for internal logic using the single source of truth
+    res_branch, res_path, res_exclude, _, _, _ = resolve_defaults(
+        args.branch,
+        args.path,
+        args.exclude,
+    )
 
     fetch_results = await fetch_upstreams_concurrently(
-        args.upstream, client, branch=branch, path=path
+        args.upstream, client, branch=res_branch, path=res_path
     )
 
     # Sequentially merge the results in the original order
@@ -769,7 +776,7 @@ async def _merge_multiple_upstreams(
             fetch_result.buffer.read(),
             is_ruff_toml=is_upstream_ruff_toml,
             create_if_missing=False,
-            exclude=exclude,
+            exclude=res_exclude,
         )
 
         target_doc = merge_ruff_toml(
@@ -806,14 +813,14 @@ def _print_diff(
     fmt.diff("".join(diff))
 
 
-def _check_pre_commit_sync(args: Arguments, fmt: ResultFormatter) -> int | None:
+def _check_pre_commit_sync(pre_commit: bool, fmt: ResultFormatter) -> int | None:
     """Return exit code 3 if pre-commit hook version is out of sync, otherwise None.
 
     Shared helper to avoid duplicating the pre-commit synchronization logic.
     Exit code 3 is reserved for pre-commit hook drift to avoid collision with
     argparse (2) and config drift (1).
     """
-    if getattr(args, "pre_commit", False) and not sync_pre_commit(pathlib.Path.cwd(), dry_run=True):
+    if pre_commit and not sync_pre_commit(pathlib.Path.cwd(), dry_run=True):
         repo_root = pathlib.Path.cwd()
         pre_commit_config = repo_root / ".pre-commit-config.yaml"
         file_path = pre_commit_config if pre_commit_config.exists() else repo_root
@@ -946,6 +953,23 @@ async def check(
         ... )
         >>> # asyncio.run(check(args))
     """
+    # Resolve defaults for execution logic
+    (
+        _res_branch,
+        _res_path,
+        _res_exclude,
+        _res_validate,
+        _res_strict,
+        res_pre_commit,
+    ) = resolve_defaults(
+        args.branch,
+        args.path,
+        args.exclude,
+        args.validate,
+        args.strict,
+        args.pre_commit,
+    )
+
     output_format = args.output_format
     fmt: ResultFormatter = get_formatter(output_format)
     try:
@@ -993,13 +1017,13 @@ async def check(
 
             if source_val == merged_val:
                 fmt.success("✅ Ruff configuration is semantically in sync.")
-                exit_code = _check_pre_commit_sync(args, fmt)
+                exit_code = _check_pre_commit_sync(res_pre_commit, fmt)
                 if exit_code is not None:
                     return exit_code
                 return 0
         elif source_doc.as_string() == merged_doc.as_string():
             fmt.success("✅ Ruff configuration is in sync.")
-            exit_code = _check_pre_commit_sync(args, fmt)
+            exit_code = _check_pre_commit_sync(res_pre_commit, fmt)
             if exit_code is not None:
                 return exit_code
             return 0
@@ -1104,8 +1128,9 @@ def serialize_ruff_sync_config(doc: TOMLDocument, args: Arguments) -> None:
         (ConfKey.VALIDATE, "validate"),
         (ConfKey.STRICT, "strict"),
     ]:
-        if getattr(args, attr, False):
-            ruff_sync_table[key] = True
+        val = getattr(args, attr, MISSING)
+        if val is not MISSING:
+            ruff_sync_table[key] = val
 
 
 async def pull(
@@ -1130,6 +1155,23 @@ async def pull(
         ... )
         >>> # asyncio.run(pull(args))
     """
+    # Resolve defaults for execution logic
+    (
+        _res_branch,
+        _res_path,
+        res_exclude,
+        res_validate,
+        res_strict,
+        res_pre_commit,
+    ) = resolve_defaults(
+        args.branch,
+        args.path,
+        args.exclude,
+        args.validate,
+        args.strict,
+        args.pre_commit,
+    )
+
     output_format = args.output_format
     fmt = get_formatter(output_format)
     try:
@@ -1167,12 +1209,12 @@ async def pull(
             )
 
         # Validation is opt-in — only run if --validate (or --strict) was passed
-        if args.validate:
+        if res_validate:
             from ruff_sync.validation import validate_merged_config  # noqa: PLC0415
 
             is_ruff_toml = is_ruff_toml_file(_source_toml_path.name)
             if not validate_merged_config(
-                source_doc, is_ruff_toml=is_ruff_toml, strict=args.strict, exclude=args.exclude
+                source_doc, is_ruff_toml=is_ruff_toml, strict=res_strict, exclude=res_exclude
             ):
                 fmt.error(
                     "❌ Merged config failed validation. Local file left unchanged.",
@@ -1198,7 +1240,7 @@ async def pull(
             rel_path = _source_toml_path.resolve()
         fmt.success(f"✅ Updated {rel_path}")
 
-        if args.pre_commit:
+        if res_pre_commit:
             sync_pre_commit(pathlib.Path.cwd(), dry_run=False)
 
         return 0

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import logging
+import os
 import sys
 from typing import Literal, Protocol, runtime_checkable
 
@@ -8,6 +9,8 @@ import pytest
 from typing_extensions import override
 
 import ruff_sync
+
+LOGGER = logging.getLogger(__name__)
 
 
 class TestStreamHandler(logging.Handler):
@@ -65,6 +68,17 @@ def clear_ruff_sync_caches():
     ruff_sync.Arguments.fields.cache_clear()
 
 
+@pytest.fixture
+def isolate_ci_env(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Ensure CI environment variables (like GITHUB_STEP_SUMMARY) are not set.
+
+    This prevents tests from polluting real CI reports when they invoke formatters.
+    """
+    if "GITHUB_STEP_SUMMARY" in os.environ:
+        LOGGER.warning("Clearing GITHUB_STEP_SUMMARY to prevent test pollution")
+        monkeypatch.delenv("GITHUB_STEP_SUMMARY", raising=False)
+
+
 @runtime_checkable
 class CLIRunner(Protocol):
     """Protocol for the cli_run fixture."""
@@ -79,7 +93,9 @@ class CLIRunner(Protocol):
 
 
 @pytest.fixture
-def cli_run(monkeypatch: pytest.MonkeyPatch, capsys: pytest.CaptureFixture[str]) -> CLIRunner:
+def cli_run(
+    monkeypatch: pytest.MonkeyPatch, capsys: pytest.CaptureFixture[str], isolate_ci_env: None
+) -> CLIRunner:
     """Fixture to run the ruff-sync CLI or entry points and capture output."""
 
     def _run(

--- a/tests/test_basic.py
+++ b/tests/test_basic.py
@@ -692,7 +692,7 @@ async def test_merge_multiple_upstreams_preserves_order(respx_mock: respx.Router
     )
 
     async with httpx.AsyncClient() as client:
-        result_doc = await _merge_multiple_upstreams(target_doc, False, args, client)
+        result_doc = await _merge_multiple_upstreams(target_doc, False, args.resolve(), client)
 
         # Verify both URLs were fetched
         assert respx_mock.get("http://one.toml").called
@@ -778,7 +778,7 @@ async def test_merge_multiple_upstreams_handles_errors(respx_mock: respx.Router)
 
     async with httpx.AsyncClient() as client:
         with pytest.raises(UpstreamError) as excinfo:
-            await _merge_multiple_upstreams(target_doc, False, args, client)
+            await _merge_multiple_upstreams(target_doc, False, args.resolve(), client)
 
         assert len(excinfo.value.errors) == 1
         url, err = excinfo.value.errors[0]

--- a/tests/test_config_validation.py
+++ b/tests/test_config_validation.py
@@ -45,9 +45,18 @@ def clean_config_cache():
     # Ensure LOGGER can be captured by caplog
     original_propagate = LOGGER.propagate
     LOGGER.propagate = True
+
+    # Clear handlers from the root ruff_sync logger to avoid "Bad file descriptor"
+    # when running multiple CLI tests that capture stdout/stderr.
+    # main() adds handlers to the 'ruff_sync' logger.
+    root_logger = logging.getLogger("ruff_sync")
+    orig_handlers = root_logger.handlers[:]
+    root_logger.handlers.clear()
+
     get_config.cache_clear()
     yield
     get_config.cache_clear()
+    root_logger.handlers = orig_handlers
     LOGGER.propagate = original_propagate
 
 
@@ -876,6 +885,50 @@ def test_pull_save_persists_validation_flags(
         assert expected in content
     for unexpected in expected_not_in_toml:
         assert unexpected not in content
+
+
+def test_pull_save_clears_validation_flags(
+    fs: FakeFilesystem,
+    cli_run: CLIRunner,
+    clean_config_cache: None,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Pull --no-strict --save must persist 'false' to [tool.ruff-sync]."""
+    fs.create_file(
+        "pyproject.toml",
+        contents=(
+            "[tool.ruff-sync]\n"
+            'upstream = "https://example.com/pyproject.toml"\n'
+            "strict = true\n"
+            "validate = true\n"
+        ),
+    )
+
+    # Mock validation logic to avoid pyfakefs/subprocess conflicts
+    monkeypatch.setattr(
+        "ruff_sync.validation.validate_ruff_accepts_config", lambda *args, **kwargs: True
+    )
+
+    with respx.mock(base_url="https://example.com") as respx_mock:
+        respx_mock.get("/pyproject.toml").respond(
+            200, content_type="text/plain", content="[tool.ruff]\n"
+        )
+
+        # Run with --no-strict --save
+        exit_code, _, _ = cli_run(["pull", "--no-strict", "--save"])
+        assert exit_code == 0
+
+        # Verify that 'strict = false' is now in the TOML
+        # Note: validate will still be true because it was in config and we only cleared strict
+        content = pathlib.Path("pyproject.toml").read_text()
+        assert "strict = false" in content
+        assert "validate = true" in content
+
+        # Now clear validate too
+        exit_code, _, _ = cli_run(["pull", "--no-validate", "--save"])
+        assert exit_code == 0
+        content = pathlib.Path("pyproject.toml").read_text()
+        assert "validate = false" in content
 
 
 if __name__ == "__main__":

--- a/tests/test_config_validation.py
+++ b/tests/test_config_validation.py
@@ -168,6 +168,7 @@ output-format = "github"
         pytest.param("validate = true\nstrict = true\n", True, True, id="both-true"),
         pytest.param("validate = true\n", True, False, id="validate-only"),
         pytest.param("strict = true\n", False, True, id="strict-only"),
+        pytest.param("", False, False, id="baseline-defaults"),
         pytest.param("", False, False, id="absent"),
     ],
 )
@@ -233,6 +234,16 @@ def test_get_config_includes_validation_flags(
             True,
             True,
             id="config-both-false-cli-both-true",
+        ),
+        # Bug regression: config `validate = false`, CLI `--strict` should force validate=True
+        # Previously this would silently set strict=False because apply_bool_precedence
+        # saw validate=False (from config) before noticing strict=True (from CLI).
+        pytest.param(
+            "validate = false\n",
+            ["--strict"],
+            True,
+            True,
+            id="config-validate-false-cli-strict",
         ),
     ],
 )

--- a/tests/test_config_validation.py
+++ b/tests/test_config_validation.py
@@ -186,6 +186,104 @@ def test_get_config_includes_validation_flags(
     assert config.get("strict", False) is expected_strict
 
 
+@pytest.mark.parametrize(
+    "config_toml, cli_args, expected_validate, expected_strict",
+    [
+        # Config `strict = true`, CLI `--no-strict` / `--no-validate` should let CLI win
+        pytest.param(
+            "validate = true\nstrict = true\n",
+            ["--no-strict"],
+            True,
+            False,
+            id="config-strict-true-cli-no-strict",
+        ),
+        pytest.param(
+            "validate = true\nstrict = true\n",
+            ["--no-validate"],
+            False,
+            False,
+            id="config-strict-true-cli-no-validate",
+        ),
+        # Config `validate = true` only, CLI `--strict` (strict still implies validate)
+        pytest.param(
+            "validate = true\n",
+            ["--strict"],
+            True,
+            True,
+            id="config-validate-true-cli-strict",
+        ),
+        pytest.param(
+            "",
+            ["--strict"],
+            True,
+            True,
+            id="config-none-cli-strict",
+        ),
+        # Config sets both flags, CLI passes them again with different values
+        pytest.param(
+            "validate = true\nstrict = true\n",
+            ["--no-validate", "--no-strict"],
+            False,
+            False,
+            id="config-both-true-cli-both-false",
+        ),
+        pytest.param(
+            "validate = false\nstrict = false\n",
+            ["--validate", "--strict"],
+            True,
+            True,
+            id="config-both-false-cli-both-true",
+        ),
+    ],
+)
+def test_validation_flags_cli_vs_config_precedence(
+    tmp_path: pathlib.Path,
+    clean_config_cache: None,
+    config_toml: str,
+    cli_args: list[str],
+    expected_validate: bool,
+    expected_strict: bool,
+):
+    """
+    Verify that CLI flags override config values where intended, and that
+    `strict` always implies `validate` regardless of whether it comes from
+    the config file or CLI flags.
+    """
+    from ruff_sync.cli import PARSER, Arguments, _resolve_strict, _resolve_validate
+
+    # Write per-test config
+    pyproject = tmp_path / "pyproject.toml"
+    pyproject.write_text(f"[tool.ruff-sync]\n{config_toml}")
+
+    # Parse CLI args
+    # We add a dummy 'upstream' to satisfy argparse requirements
+    parsed_args = PARSER.parse_args(["pull", "https://example.com", *cli_args])
+
+    # Get config (from the mocked pyproject.toml)
+    config = get_config(tmp_path)
+
+    # Resolve to Arguments (transport layer)
+    args = Arguments(
+        command=parsed_args.command,
+        upstream=tuple(parsed_args.upstream),
+        to=tmp_path,
+        exclude=[],
+        verbose=0,
+        validate=_resolve_validate(parsed_args, config),
+        strict=_resolve_strict(parsed_args, config),
+    )
+
+    # Resolve to ExecutionArgs (logic layer)
+    exec_args = args.resolve()
+
+    assert exec_args.validate is expected_validate
+    assert exec_args.strict is expected_strict
+
+    # Guard that `strict` continues to imply `validate` at runtime
+    if exec_args.strict:
+        assert exec_args.validate is True
+
+
 # ===========================================================================
 # Phase 1 — validate_toml_syntax
 # ===========================================================================
@@ -683,6 +781,8 @@ def test_strict_mode_fails_on_version_mismatch(caplog: pytest.LogCaptureFixture)
         '[project]\nrequires-python = ">=3.10"\n\n[tool.ruff]\ntarget-version = "py39"\n'
     )
     with caplog.at_level(logging.ERROR, logger="ruff_sync.validation"):
+        from ruff_sync.validation import validate_merged_config
+
         result = validate_merged_config(doc, strict=True)
 
     assert result is False

--- a/tests/test_config_validation.py
+++ b/tests/test_config_validation.py
@@ -153,21 +153,28 @@ output-format = "github"
     assert config["output_format"] == "github"
 
 
+@pytest.mark.parametrize(
+    "config_toml, expected_validate, expected_strict",
+    [
+        pytest.param("validate = true\nstrict = true\n", True, True, id="both-true"),
+        pytest.param("validate = true\n", True, False, id="validate-only"),
+        pytest.param("strict = true\n", False, True, id="strict-only"),
+        pytest.param("", False, False, id="absent"),
+    ],
+)
 def test_get_config_includes_validation_flags(
-    tmp_path: pathlib.Path, clean_config_cache: None
+    tmp_path: pathlib.Path,
+    clean_config_cache: None,
+    config_toml: str,
+    expected_validate: bool,
+    expected_strict: bool,
 ) -> None:
     """Verify that validate and strict flags are correctly read from config."""
     pyproject = tmp_path / "pyproject.toml"
-    pyproject.write_text(
-        """
-[tool.ruff-sync]
-validate = true
-strict = true
-"""
-    )
+    pyproject.write_text(f"[tool.ruff-sync]\n{config_toml}")
     config = get_config(tmp_path)
-    assert config["validate"] is True
-    assert config["strict"] is True
+    assert config.get("validate", False) is expected_validate
+    assert config.get("strict", False) is expected_strict
 
 
 # ===========================================================================
@@ -746,24 +753,59 @@ def test_non_strict_mode_passes_on_deprecated_rules(caplog: pytest.LogCaptureFix
     assert "deprecated rule 'UP036'" in caplog.text
 
 
-def test_pull_uses_persisted_strict_mode(
+@pytest.mark.parametrize(
+    "config_toml, ruff_stderr, ruff_exit_code, expected_exit_code, expected_msg",
+    [
+        pytest.param(
+            "strict = true",
+            "warning: config obsolete",
+            0,
+            1,
+            "Ruff validation warning(s) detected in strict mode",
+            id="strict-fails-on-warning",
+        ),
+        pytest.param(
+            "validate = true",
+            "error: unknown field",
+            2,
+            1,
+            "Merged config failed validation",
+            id="validate-fails-on-error",
+        ),
+        pytest.param(
+            "",  # No validation in config
+            "warning: config obsolete",
+            0,
+            0,
+            None,
+            id="opt-in-by-default",
+        ),
+    ],
+)
+def test_pull_uses_persisted_validation_settings(
     fs: FakeFilesystem,
     monkeypatch: pytest.MonkeyPatch,
     caplog: pytest.LogCaptureFixture,
     cli_run: CLIRunner,
+    clean_config_cache: None,
+    config_toml: str,
+    ruff_stderr: str,
+    ruff_exit_code: int,
+    expected_exit_code: int,
+    expected_msg: str | None,
 ) -> None:
-    """Pull must honor 'strict = true' defined in [tool.ruff-sync] even without CLI flags."""
+    """Pull must honor validation settings defined in [tool.ruff-sync]."""
     fs.create_file(
         "pyproject.toml",
         contents=(
-            '[tool.ruff-sync]\nupstream = "https://example.com/pyproject.toml"\nstrict = true\n'
+            f'[tool.ruff-sync]\nupstream = "https://example.com/pyproject.toml"\n{config_toml}\n'
         ),
     )
 
-    # Simulate ruff rejecting the config with a warning
+    # Simulate ruff behavior
     def fake_run(cmd: list[str], **kwargs: object) -> subprocess.CompletedProcess[str]:
         return subprocess.CompletedProcess(
-            args=cmd, returncode=0, stdout="", stderr="warning: config obsolete"
+            args=cmd, returncode=ruff_exit_code, stdout="", stderr=ruff_stderr
         )
 
     monkeypatch.setattr("ruff_sync.validation.subprocess.run", fake_run)
@@ -776,17 +818,38 @@ def test_pull_uses_persisted_strict_mode(
         with caplog.at_level(logging.ERROR, logger="ruff_sync.validation"):
             exit_code, _, _ = cli_run(["pull"])
 
-    # Should abort due to strict=True in config
-    assert exit_code == 1
-    assert "Ruff validation warning(s) detected in strict mode" in caplog.text
+    assert exit_code == expected_exit_code
+    if expected_msg:
+        assert expected_msg in caplog.text
 
 
+@pytest.mark.parametrize(
+    "cli_flags, expected_in_toml, expected_not_in_toml",
+    [
+        pytest.param(
+            ["--strict"],
+            ["strict = true", "validate = true"],
+            [],
+            id="strict-persists-both",
+        ),
+        pytest.param(
+            ["--validate"],
+            ["validate = true"],
+            ["strict = true"],
+            id="validate-persists-only-validate",
+        ),
+    ],
+)
 def test_pull_save_persists_validation_flags(
     fs: FakeFilesystem,
     monkeypatch: pytest.MonkeyPatch,
     cli_run: CLIRunner,
+    clean_config_cache: None,
+    cli_flags: list[str],
+    expected_in_toml: list[str],
+    expected_not_in_toml: list[str],
 ) -> None:
-    """Pull --save --strict must persist strict=true and validate=true to [tool.ruff-sync]."""
+    """Pull --save with validation flags must persist them to [tool.ruff-sync]."""
     fs.create_file(
         "pyproject.toml",
         contents='[tool.ruff-sync]\nupstream = "https://example.com/pyproject.toml"\n',
@@ -804,13 +867,15 @@ def test_pull_save_persists_validation_flags(
             200, content_type="text/plain", content="[tool.ruff]\n"
         )
 
-        # Run with --save --strict
-        exit_code, _, _ = cli_run(["pull", "--save", "--strict"])
+        # Run with --save and the parametrized flags
+        exit_code, _, _ = cli_run(["pull", "--save", *cli_flags])
 
     assert exit_code == 0
     content = source_path.read_text()
-    assert "strict = true" in content
-    assert "validate = true" in content
+    for expected in expected_in_toml:
+        assert expected in content
+    for unexpected in expected_not_in_toml:
+        assert unexpected not in content
 
 
 if __name__ == "__main__":

--- a/tests/test_config_validation.py
+++ b/tests/test_config_validation.py
@@ -31,6 +31,8 @@ from ruff_sync.validation import (
 if TYPE_CHECKING:
     from pyfakefs.fake_filesystem import FakeFilesystem
 
+    from tests.conftest import CLIRunner
+
 
 # ---------------------------------------------------------------------------
 # Fixture shared by the legacy get_config tests
@@ -149,6 +151,23 @@ output-format = "github"
     # The last one in the file wins if they map to the same key.
     assert config["pre_commit_version_sync"] is True
     assert config["output_format"] == "github"
+
+
+def test_get_config_includes_validation_flags(
+    tmp_path: pathlib.Path, clean_config_cache: None
+) -> None:
+    """Verify that validate and strict flags are correctly read from config."""
+    pyproject = tmp_path / "pyproject.toml"
+    pyproject.write_text(
+        """
+[tool.ruff-sync]
+validate = true
+strict = true
+"""
+    )
+    config = get_config(tmp_path)
+    assert config["validate"] is True
+    assert config["strict"] is True
 
 
 # ===========================================================================
@@ -725,6 +744,73 @@ def test_non_strict_mode_passes_on_deprecated_rules(caplog: pytest.LogCaptureFix
         result = check_deprecated_rules(doc, strict=False, _deprecated_codes=frozenset({"UP036"}))
     assert result is True
     assert "deprecated rule 'UP036'" in caplog.text
+
+
+def test_pull_uses_persisted_strict_mode(
+    fs: FakeFilesystem,
+    monkeypatch: pytest.MonkeyPatch,
+    caplog: pytest.LogCaptureFixture,
+    cli_run: CLIRunner,
+) -> None:
+    """Pull must honor 'strict = true' defined in [tool.ruff-sync] even without CLI flags."""
+    fs.create_file(
+        "pyproject.toml",
+        contents=(
+            '[tool.ruff-sync]\nupstream = "https://example.com/pyproject.toml"\nstrict = true\n'
+        ),
+    )
+
+    # Simulate ruff rejecting the config with a warning
+    def fake_run(cmd: list[str], **kwargs: object) -> subprocess.CompletedProcess[str]:
+        return subprocess.CompletedProcess(
+            args=cmd, returncode=0, stdout="", stderr="warning: config obsolete"
+        )
+
+    monkeypatch.setattr("ruff_sync.validation.subprocess.run", fake_run)
+
+    with respx.mock(base_url="https://example.com") as respx_mock:
+        respx_mock.get("/pyproject.toml").respond(
+            200, content_type="text/plain", content="[tool.ruff]\n"
+        )
+
+        with caplog.at_level(logging.ERROR, logger="ruff_sync.validation"):
+            exit_code, _, _ = cli_run(["pull"])
+
+    # Should abort due to strict=True in config
+    assert exit_code == 1
+    assert "Ruff validation warning(s) detected in strict mode" in caplog.text
+
+
+def test_pull_save_persists_validation_flags(
+    fs: FakeFilesystem,
+    monkeypatch: pytest.MonkeyPatch,
+    cli_run: CLIRunner,
+) -> None:
+    """Pull --save --strict must persist strict=true and validate=true to [tool.ruff-sync]."""
+    fs.create_file(
+        "pyproject.toml",
+        contents='[tool.ruff-sync]\nupstream = "https://example.com/pyproject.toml"\n',
+    )
+    source_path = pathlib.Path("pyproject.toml")
+
+    # Mock success validation
+    def fake_run(cmd: list[str], **kwargs: object) -> subprocess.CompletedProcess[str]:
+        return subprocess.CompletedProcess(args=cmd, returncode=0, stdout="", stderr="")
+
+    monkeypatch.setattr("ruff_sync.validation.subprocess.run", fake_run)
+
+    with respx.mock(base_url="https://example.com") as respx_mock:
+        respx_mock.get("/pyproject.toml").respond(
+            200, content_type="text/plain", content="[tool.ruff]\n"
+        )
+
+        # Run with --save --strict
+        exit_code, _, _ = cli_run(["pull", "--save", "--strict"])
+
+    assert exit_code == 0
+    content = source_path.read_text()
+    assert "strict = true" in content
+    assert "validate = true" in content
 
 
 if __name__ == "__main__":

--- a/tests/test_constants.py
+++ b/tests/test_constants.py
@@ -68,7 +68,7 @@ def test_resolve_bool_flags_all_missing():
     validate, strict, pre_commit = resolve_bool_flags(MISSING, MISSING, MISSING)
     assert validate is False
     assert strict is False
-    assert pre_commit is True
+    assert pre_commit is False
 
 
 def test_resolve_bool_flags_strict_implies_validate():
@@ -77,10 +77,10 @@ def test_resolve_bool_flags_strict_implies_validate():
     assert validate is True
     assert strict is True
 
-    # Even if validate is explicitly False, strict=True wins
+    # If validate is explicitly False, it wins and disables strict mode
     validate, strict, _ = resolve_bool_flags(False, True, MISSING)
-    assert validate is True
-    assert strict is True
+    assert validate is False
+    assert strict is False
 
 
 def test_resolve_bool_flags_explicit_false():

--- a/tests/test_constants.py
+++ b/tests/test_constants.py
@@ -10,38 +10,48 @@ from ruff_sync.constants import (
 
 def test_resolve_defaults_all_missing():
     """Verify that MISSING for all args resolves to project defaults."""
-    branch, path, exclude = resolve_defaults(MISSING, MISSING, MISSING)
+    branch, path, exclude, validate, strict, pre_commit = resolve_defaults(
+        MISSING, MISSING, MISSING
+    )
 
     assert branch == DEFAULT_BRANCH
     assert path is None  # DEFAULT_PATH ("") is normalized to None
     assert exclude == DEFAULT_EXCLUDE
+    assert validate is False
+    assert strict is False
+    assert pre_commit is True
 
 
 def test_resolve_defaults_passthrough():
     """Verify that non-MISSING values are passed through unchanged."""
-    branch, path, exclude = resolve_defaults("develop", "src", ["rule1"])
+    branch, path, exclude, validate, strict, pre_commit = resolve_defaults(
+        "develop", "src", ["rule1"], validate=True, strict=True, pre_commit=False
+    )
 
     assert branch == "develop"
     assert path == "src"
-    assert exclude == ["rule1"]
+    assert list(exclude) == ["rule1"]
+    assert validate is True
+    assert strict is True
+    assert pre_commit is False
 
 
 def test_resolve_defaults_mixed():
     """Verify mixed combinations of MISSING and explicit values."""
     # Case: branch is MISSING, others are explicit
-    branch, path, exclude = resolve_defaults(MISSING, "subdir", ["exclude1"])
+    branch, path, exclude, _, _, _ = resolve_defaults(MISSING, "subdir", ["exclude1"])
     assert branch == DEFAULT_BRANCH
     assert path == "subdir"
     assert exclude == ["exclude1"]
 
     # Case: path is MISSING, others are explicit
-    branch, path, exclude = resolve_defaults("feat/branch", MISSING, ["exclude2"])
+    branch, path, exclude, _, _, _ = resolve_defaults("feat/branch", MISSING, ["exclude2"])
     assert branch == "feat/branch"
     assert path is None  # MISSING normalized to None
     assert exclude == ["exclude2"]
 
     # Case: exclude is MISSING, others are explicit
-    branch, path, exclude = resolve_defaults("main", "root", MISSING)
+    branch, path, exclude, _, _, _ = resolve_defaults("main", "root", MISSING)
     assert branch == "main"
     assert path == "root"
     assert exclude == DEFAULT_EXCLUDE
@@ -50,13 +60,13 @@ def test_resolve_defaults_mixed():
 def test_resolve_defaults_path_normalization():
     """Verify that empty string paths are normalized to None."""
     # Explicit empty string
-    _, path, _ = resolve_defaults("main", "", MISSING)
+    _, path, _, _, _, _ = resolve_defaults("main", "", MISSING)
     assert path is None
 
     # MISSING (which is DEFAULT_PATH which is "")
-    _, path, _ = resolve_defaults("main", MISSING, MISSING)
+    _, path, _, _, _, _ = resolve_defaults("main", MISSING, MISSING)
     assert path is None
 
     # Non-empty string remains
-    _, path, _ = resolve_defaults("main", "backend", MISSING)
+    _, path, _, _, _, _ = resolve_defaults("main", "backend", MISSING)
     assert path == "backend"

--- a/tests/test_constants.py
+++ b/tests/test_constants.py
@@ -4,54 +4,45 @@ from ruff_sync.constants import (
     DEFAULT_BRANCH,
     DEFAULT_EXCLUDE,
     MISSING,
+    resolve_bool_flags,
     resolve_defaults,
 )
 
 
 def test_resolve_defaults_all_missing():
     """Verify that MISSING for all args resolves to project defaults."""
-    branch, path, exclude, validate, strict, pre_commit = resolve_defaults(
-        MISSING, MISSING, MISSING
-    )
+    branch, path, exclude = resolve_defaults(MISSING, MISSING, MISSING)
 
     assert branch == DEFAULT_BRANCH
     assert path is None  # DEFAULT_PATH ("") is normalized to None
     assert exclude == DEFAULT_EXCLUDE
-    assert validate is False
-    assert strict is False
-    assert pre_commit is True
 
 
 def test_resolve_defaults_passthrough():
     """Verify that non-MISSING values are passed through unchanged."""
-    branch, path, exclude, validate, strict, pre_commit = resolve_defaults(
-        "develop", "src", ["rule1"], validate=True, strict=True, pre_commit=False
-    )
+    branch, path, exclude = resolve_defaults("develop", "src", ["rule1"])
 
     assert branch == "develop"
     assert path == "src"
     assert list(exclude) == ["rule1"]
-    assert validate is True
-    assert strict is True
-    assert pre_commit is False
 
 
 def test_resolve_defaults_mixed():
     """Verify mixed combinations of MISSING and explicit values."""
     # Case: branch is MISSING, others are explicit
-    branch, path, exclude, _, _, _ = resolve_defaults(MISSING, "subdir", ["exclude1"])
+    branch, path, exclude = resolve_defaults(MISSING, "subdir", ["exclude1"])
     assert branch == DEFAULT_BRANCH
     assert path == "subdir"
     assert exclude == ["exclude1"]
 
     # Case: path is MISSING, others are explicit
-    branch, path, exclude, _, _, _ = resolve_defaults("feat/branch", MISSING, ["exclude2"])
+    branch, path, exclude = resolve_defaults("feat/branch", MISSING, ["exclude2"])
     assert branch == "feat/branch"
     assert path is None  # MISSING normalized to None
     assert exclude == ["exclude2"]
 
     # Case: exclude is MISSING, others are explicit
-    branch, path, exclude, _, _, _ = resolve_defaults("main", "root", MISSING)
+    branch, path, exclude = resolve_defaults("main", "root", MISSING)
     assert branch == "main"
     assert path == "root"
     assert exclude == DEFAULT_EXCLUDE
@@ -60,13 +51,41 @@ def test_resolve_defaults_mixed():
 def test_resolve_defaults_path_normalization():
     """Verify that empty string paths are normalized to None."""
     # Explicit empty string
-    _, path, _, _, _, _ = resolve_defaults("main", "", MISSING)
+    _, path, _ = resolve_defaults("main", "", MISSING)
     assert path is None
 
     # MISSING (which is DEFAULT_PATH which is "")
-    _, path, _, _, _, _ = resolve_defaults("main", MISSING, MISSING)
+    _, path, _ = resolve_defaults("main", MISSING, MISSING)
     assert path is None
 
     # Non-empty string remains
-    _, path, _, _, _, _ = resolve_defaults("main", "backend", MISSING)
+    _, path, _ = resolve_defaults("main", "backend", MISSING)
     assert path == "backend"
+
+
+def test_resolve_bool_flags_all_missing():
+    """Verify that MISSING for all flags resolves to project defaults."""
+    validate, strict, pre_commit = resolve_bool_flags(MISSING, MISSING, MISSING)
+    assert validate is False
+    assert strict is False
+    assert pre_commit is True
+
+
+def test_resolve_bool_flags_strict_implies_validate():
+    """Verify that strict=True implies validate=True."""
+    validate, strict, _ = resolve_bool_flags(MISSING, True, MISSING)
+    assert validate is True
+    assert strict is True
+
+    # Even if validate is explicitly False, strict=True wins
+    validate, strict, _ = resolve_bool_flags(False, True, MISSING)
+    assert validate is True
+    assert strict is True
+
+
+def test_resolve_bool_flags_explicit_false():
+    """Verify that explicit False values are preserved."""
+    validate, strict, pre_commit = resolve_bool_flags(False, False, False)
+    assert validate is False
+    assert strict is False
+    assert pre_commit is False

--- a/tests/test_formatters.py
+++ b/tests/test_formatters.py
@@ -29,7 +29,7 @@ if TYPE_CHECKING:
 @pytest.fixture(
     params=[TextFormatter, GithubFormatter, JsonFormatter, GitlabFormatter, SarifFormatter]
 )
-def formatter(request: pytest.FixtureRequest) -> ResultFormatter:
+def formatter(request: pytest.FixtureRequest, isolate_ci_env: None) -> ResultFormatter:
     """Fixture providing instances of ALL available formatters."""
     formatter_cls: type[ResultFormatter] = request.param
     return formatter_cls()
@@ -164,7 +164,9 @@ class TestGithubFormatterSpecifics:
         captured = capsys.readouterr().out
         assert "::debug::debug msg" in captured
 
-    def test_error_and_warning_are_accumulated(self, capsys: pytest.CaptureFixture[str]) -> None:
+    def test_error_and_warning_are_accumulated(
+        self, capsys: pytest.CaptureFixture[str], isolate_ci_env: None
+    ) -> None:
         """error() and warning() must not emit output until finalize() is called."""
         fmt = GithubFormatter()
         fmt.error("error msg")
@@ -179,7 +181,9 @@ class TestGithubFormatterSpecifics:
         assert "::error" in captured
         assert "::warning" in captured
 
-    def test_emoji_stripping(self, capsys: pytest.CaptureFixture[str]) -> None:
+    def test_emoji_stripping(
+        self, capsys: pytest.CaptureFixture[str], isolate_ci_env: None
+    ) -> None:
         """Ensure leading status icons are stripped from GitHub-specific output."""
         fmt = GithubFormatter()
         fmt.error("❌ error msg")
@@ -190,7 +194,9 @@ class TestGithubFormatterSpecifics:
         assert "title=Ruff Sync Error::error msg" in captured
         assert "title=Ruff Sync Warning::warning msg" in captured
 
-    def test_single_issue_has_precision(self, capsys: pytest.CaptureFixture[str]) -> None:
+    def test_single_issue_has_precision(
+        self, capsys: pytest.CaptureFixture[str], isolate_ci_env: None
+    ) -> None:
         """A single issue should still include line=1 and the raw message."""
         fmt = GithubFormatter()
         fmt.error("msg", file_path=pathlib.Path("src/foo.py"))
@@ -200,7 +206,9 @@ class TestGithubFormatterSpecifics:
         assert "::error" in captured
         assert "::msg" in captured
 
-    def test_multiple_issues_are_combined(self, capsys: pytest.CaptureFixture[str]) -> None:
+    def test_multiple_issues_are_combined(
+        self, capsys: pytest.CaptureFixture[str], isolate_ci_env: None
+    ) -> None:
         """Multiple issues in the same file should be combined into one annotation."""
         fmt = GithubFormatter()
         path = pathlib.Path("pyproject.toml")
@@ -238,7 +246,7 @@ class TestGithubFormatterSpecifics:
         assert "| `target-version` | warn msg |" in content
 
     def test_step_summary_no_env(
-        self, tmp_path: pathlib.Path, capsys: pytest.CaptureFixture[str]
+        self, tmp_path: pathlib.Path, capsys: pytest.CaptureFixture[str], isolate_ci_env: None
     ) -> None:
         """Finalize should work fine and output nothing to summary if env var is missing."""
         fmt = GithubFormatter()

--- a/tests/test_serialization.py
+++ b/tests/test_serialization.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 import logging
 import pathlib
+from typing import Any, cast
 
 import pytest
 import tomlkit
@@ -78,6 +79,96 @@ def test_serialize_validate_and_strict_missing():
     # When validate/strict are MISSING, they should not be persisted
     assert "validate" not in toml_str
     assert "strict" not in toml_str
+
+
+def test_serialize_validate_explicit_strict_missing():
+    """Validate is explicit, strict is MISSING -> only validate is serialized."""
+    # validate=True
+    doc = tomlkit.document()
+    doc["tool"] = {"ruff-sync": {}}
+
+    args = Arguments(
+        command="pull",
+        upstream=(URL("https://example.com/repo/pyproject.toml"),),
+        to=pathlib.Path(),
+        exclude=DEFAULT_EXCLUDE,
+        verbose=0,
+        pre_commit=MISSING,
+        validate=True,
+        strict=MISSING,
+    )
+
+    serialize_ruff_sync_config(doc, args)
+
+    ruff_sync = cast("Any", doc)["tool"]["ruff-sync"]
+    assert ruff_sync["validate"] is True
+    assert "strict" not in ruff_sync
+
+    # validate=False
+    doc = tomlkit.document()
+    doc["tool"] = {"ruff-sync": {}}
+
+    args = Arguments(
+        command="pull",
+        upstream=(URL("https://example.com/repo/pyproject.toml"),),
+        to=pathlib.Path(),
+        exclude=DEFAULT_EXCLUDE,
+        verbose=0,
+        pre_commit=MISSING,
+        validate=False,
+        strict=MISSING,
+    )
+
+    serialize_ruff_sync_config(doc, args)
+
+    ruff_sync = cast("Any", doc)["tool"]["ruff-sync"]
+    assert ruff_sync["validate"] is False
+    assert "strict" not in ruff_sync
+
+
+def test_serialize_strict_explicit_validate_missing():
+    """Strict is explicit, validate is MISSING -> only strict is serialized."""
+    # strict=True
+    doc = tomlkit.document()
+    doc["tool"] = {"ruff-sync": {}}
+
+    args = Arguments(
+        command="pull",
+        upstream=(URL("https://example.com/repo/pyproject.toml"),),
+        to=pathlib.Path(),
+        exclude=DEFAULT_EXCLUDE,
+        verbose=0,
+        pre_commit=MISSING,
+        validate=MISSING,
+        strict=True,
+    )
+
+    serialize_ruff_sync_config(doc, args)
+
+    ruff_sync = cast("Any", doc)["tool"]["ruff-sync"]
+    assert ruff_sync["strict"] is True
+    assert "validate" not in ruff_sync
+
+    # strict=False
+    doc = tomlkit.document()
+    doc["tool"] = {"ruff-sync": {}}
+
+    args = Arguments(
+        command="pull",
+        upstream=(URL("https://example.com/repo/pyproject.toml"),),
+        to=pathlib.Path(),
+        exclude=DEFAULT_EXCLUDE,
+        verbose=0,
+        pre_commit=MISSING,
+        validate=MISSING,
+        strict=False,
+    )
+
+    serialize_ruff_sync_config(doc, args)
+
+    ruff_sync = cast("Any", doc)["tool"]["ruff-sync"]
+    assert ruff_sync["strict"] is False
+    assert "validate" not in ruff_sync
 
 
 def test_serialize_validate_and_strict_explicit():

--- a/tests/test_serialization.py
+++ b/tests/test_serialization.py
@@ -8,7 +8,7 @@ import tomlkit
 from httpx import URL
 
 from ruff_sync.cli import Arguments
-from ruff_sync.constants import DEFAULT_BRANCH, DEFAULT_EXCLUDE
+from ruff_sync.constants import DEFAULT_BRANCH, DEFAULT_EXCLUDE, MISSING
 from ruff_sync.core import pull, serialize_ruff_sync_config
 
 
@@ -49,7 +49,7 @@ def test_serialize_ruff_sync_config_pre_commit_default_skipped():
         to=pathlib.Path(),
         exclude=DEFAULT_EXCLUDE,
         verbose=0,
-        pre_commit=False,
+        pre_commit=MISSING,
     )
     serialize_ruff_sync_config(doc, args)
 
@@ -168,7 +168,7 @@ def test_serialize_ruff_sync_config_omits_defaults():
         verbose=0,
         branch=DEFAULT_BRANCH,
         path=None,
-        pre_commit=False,
+        pre_commit=MISSING,
         save=True,
     )
     serialize_ruff_sync_config(doc, args)
@@ -265,18 +265,16 @@ def test_serialize_ruff_sync_config_multiple_upstreams():
     "case",
     [
         # (init, save, pre_commit, expect_sync_pre_commit, expect_save)
-        # baseline: init+save with explicit pre_commit=True triggers sync
-        (True, None, True, True, True),
+        # MISSING now defaults to True for sync
+        (True, None, MISSING, True, True),
+        # explicit False disables sync
+        (True, None, False, False, True),
         # save without init still writes [tool.ruff-sync] but does not init hooks
-        (False, True, False, False, True),
-        # neither init nor save is truthy: no [tool.ruff-sync] section should appear
-        (True, None, False, False, True),
-        # neither init nor save is truthy: no [tool.ruff-sync] section should appear
-        (True, None, False, False, True),
+        (False, True, MISSING, True, True),
         # init with explicit --no-save should not serialize [tool.ruff-sync]
-        (True, False, False, False, False),
-        # neither init nor save is truthy: no [tool.ruff-sync] section should appear
-        (False, None, False, False, False),
+        (True, False, MISSING, True, False),
+        # neither init nor save is truthy: no [tool.ruff-sync] section written
+        (False, None, MISSING, True, False),
     ],
 )
 @pytest.mark.asyncio

--- a/tests/test_serialization.py
+++ b/tests/test_serialization.py
@@ -57,6 +57,52 @@ def test_serialize_ruff_sync_config_pre_commit_default_skipped():
     assert "pre-commit-version-sync" not in s
 
 
+def test_serialize_validate_and_strict_missing():
+    doc = tomlkit.document()
+    doc["tool"] = {"ruff-sync": {}}
+
+    args = Arguments(
+        command="pull",
+        upstream=(URL("https://example.com/repo/pyproject.toml"),),
+        to=pathlib.Path(),
+        exclude=DEFAULT_EXCLUDE,
+        verbose=0,
+        pre_commit=MISSING,
+        validate=MISSING,
+        strict=MISSING,
+    )
+
+    serialize_ruff_sync_config(doc, args)
+    toml_str = tomlkit.dumps(doc)
+
+    # When validate/strict are MISSING, they should not be persisted
+    assert "validate" not in toml_str
+    assert "strict" not in toml_str
+
+
+def test_serialize_validate_and_strict_explicit():
+    doc = tomlkit.document()
+    doc["tool"] = {"ruff-sync": {}}
+
+    args = Arguments(
+        command="pull",
+        upstream=(URL("https://example.com/repo/pyproject.toml"),),
+        to=pathlib.Path(),
+        exclude=DEFAULT_EXCLUDE,
+        verbose=0,
+        pre_commit=MISSING,
+        validate=True,
+        strict=False,
+    )
+
+    serialize_ruff_sync_config(doc, args)
+    toml_str = tomlkit.dumps(doc)
+
+    # When validate/strict are explicitly provided, they should be persisted
+    assert "validate = true" in toml_str
+    assert "strict = false" in toml_str
+
+
 def test_serialize_ruff_sync_config_exclude_deduplication():
     # Case: duplicates and extra entries -> written, deduped, first-occurrence order
     doc = tomlkit.document()
@@ -265,16 +311,16 @@ def test_serialize_ruff_sync_config_multiple_upstreams():
     "case",
     [
         # (init, save, pre_commit, expect_sync_pre_commit, expect_save)
-        # MISSING now defaults to True for sync
-        (True, None, MISSING, True, True),
+        # MISSING now defaults to False for sync (preserving historical behavior)
+        (True, None, MISSING, False, True),
         # explicit False disables sync
         (True, None, False, False, True),
         # save without init still writes [tool.ruff-sync] but does not init hooks
-        (False, True, MISSING, True, True),
+        (False, True, MISSING, False, True),
         # init with explicit --no-save should not serialize [tool.ruff-sync]
-        (True, False, MISSING, True, False),
+        (True, False, MISSING, False, False),
         # neither init nor save is truthy: no [tool.ruff-sync] section written
-        (False, None, MISSING, True, False),
+        (False, None, MISSING, False, False),
     ],
 )
 @pytest.mark.asyncio

--- a/uv.lock
+++ b/uv.lock
@@ -1610,7 +1610,7 @@ wheels = [
 
 [[package]]
 name = "ruff-sync"
-version = "0.1.6.dev3"
+version = "0.1.6.dev4"
 source = { editable = "." }
 dependencies = [
     { name = "httpx" },


### PR DESCRIPTION
## Summary by Sourcery

Refine CLI argument resolution for validation, strictness, and pre-commit flags while improving config persistence and test isolation.

New Features:
- Introduce global --validate/--no-validate and --strict/--no-strict flags shared across subcommands.
- Add ExecutionArgs as a dedicated execution-layer argument container with resolved boolean defaults.
- Persist validate/strict settings from CLI to [tool.ruff-sync] when using pull --save, including explicit false values.

Bug Fixes:
- Ensure CLI validation and strict flags correctly override configuration values and maintain the invariant that strict implies validate.
- Fix flaky tests by clearing ruff_sync logger handlers between runs and isolating CI-related environment variables such as GITHUB_STEP_SUMMARY.
- Prevent GitHub formatter tests from polluting real CI step summaries by stripping CI env vars during tests.
- Ensure pre-commit sync and validation behavior in pull and check use resolved defaults rather than ambiguous sentinel values.

Enhancements:
- Centralize boolean flag defaulting logic via resolve_bool_flags and apply_bool_precedence, clarifying how validate, strict, and pre_commit interact.
- Separate transport/serialization arguments from execution arguments, simplifying core logic and type usage.
- Extend config schema and serialization to support validate and strict fields alongside existing options.
- Improve pull and check flows to use a single resolved argument set for upstream merging, validation, and pre-commit synchronization.
- Document the argument-resolution architecture and refactor plan in internal ADRs and design notes for future contributors.

Documentation:
- Update internal testing guidelines to require isolation from CI environment side effects such as writing to GITHUB_STEP_SUMMARY.
- Add an ADR and supporting design document describing the two-layer argument resolution approach and refactoring plan.

Tests:
- Add extensive tests for validate/strict precedence between CLI and config, and for persistence/clearing of these flags when using pull --save.
- Add tests covering the behavior of resolve_bool_flags and serialization of validate/strict when values are missing or explicit.
- Update existing tests to use ExecutionArgs where appropriate and to avoid CI environment side effects, particularly around formatter behavior.